### PR TITLE
feat: Фаза 0 — хардненинг и быстрые правки модерации

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -7,6 +7,7 @@ import sentry_sdk
 from telegram import Update
 from telegram.ext import Application, ChatMemberHandler, CommandHandler, MessageHandler, filters
 
+from core.allowlist import resolve_allowlist, restricted_to_allowed_chats
 from core.config import SENTRY_DSN, TELEGRAM_BOT_TOKEN
 from handlers.admin_handlers import ban_user, mute_user, unban_user, unmute_user
 from handlers.info_handlers import help_command, start
@@ -20,37 +21,40 @@ logger = logging.getLogger(__name__)
 def main() -> None:
     sentry_sdk.init(SENTRY_DSN, traces_sample_rate=1.0)
 
-    application = Application.builder().token(TELEGRAM_BOT_TOKEN).build()
+    # Resolve the configured allowlist (@usernames -> ids) once the bot is ready.
+    application = Application.builder().token(TELEGRAM_BOT_TOKEN).post_init(resolve_allowlist).build()
 
+    # Every handler is gated by the chat allowlist so the bot only acts in
+    # configured chats (and private DMs); foreign chats are left silently.
     # Keep track of which chats the bot is in
-    application.add_handler(CommandHandler("ping", ping))
+    application.add_handler(CommandHandler("ping", restricted_to_allowed_chats(ping)))
     # Greeting / private intro
-    application.add_handler(CommandHandler("start", start))
+    application.add_handler(CommandHandler("start", restricted_to_allowed_chats(start)))
     # Command and rules reference
-    application.add_handler(CommandHandler("help", help_command))
+    application.add_handler(CommandHandler("help", restricted_to_allowed_chats(help_command)))
     # Ban user manual
-    application.add_handler(CommandHandler("ban", ban_user))
+    application.add_handler(CommandHandler("ban", restricted_to_allowed_chats(ban_user)))
     # Unban user manual
-    application.add_handler(CommandHandler("unban", unban_user))
+    application.add_handler(CommandHandler("unban", restricted_to_allowed_chats(unban_user)))
     # Mute user manual
-    application.add_handler(CommandHandler("mute", mute_user))
+    application.add_handler(CommandHandler("mute", restricted_to_allowed_chats(mute_user)))
     # Unmute user manual
-    application.add_handler(CommandHandler("unmute", unmute_user))
+    application.add_handler(CommandHandler("unmute", restricted_to_allowed_chats(unmute_user)))
 
     # Welcome message
-    application.add_handler(ChatMemberHandler(greet_chat_members, ChatMemberHandler.CHAT_MEMBER))
+    application.add_handler(ChatMemberHandler(restricted_to_allowed_chats(greet_chat_members), ChatMemberHandler.CHAT_MEMBER))
     # Delete voice message
-    application.add_handler(MessageHandler(filters.VOICE, delete_bad_message))
+    application.add_handler(MessageHandler(filters.VOICE, restricted_to_allowed_chats(delete_bad_message)))
     # Delete video message
-    application.add_handler(MessageHandler(filters.VIDEO, delete_bad_message))
+    application.add_handler(MessageHandler(filters.VIDEO, restricted_to_allowed_chats(delete_bad_message)))
     # Delete locations
-    application.add_handler(MessageHandler(filters.LOCATION, delete_bad_message))
+    application.add_handler(MessageHandler(filters.LOCATION, restricted_to_allowed_chats(delete_bad_message)))
     # Delete video note
-    application.add_handler(MessageHandler(filters.VIDEO_NOTE, delete_bad_message))
+    application.add_handler(MessageHandler(filters.VIDEO_NOTE, restricted_to_allowed_chats(delete_bad_message)))
     # Delete left chat member
-    application.add_handler(MessageHandler(filters.StatusUpdate.LEFT_CHAT_MEMBER, delete_bad_message))
+    application.add_handler(MessageHandler(filters.StatusUpdate.LEFT_CHAT_MEMBER, restricted_to_allowed_chats(delete_bad_message)))
     # Delete new chat member
-    application.add_handler(MessageHandler(filters.StatusUpdate.NEW_CHAT_MEMBERS, delete_bad_message))
+    application.add_handler(MessageHandler(filters.StatusUpdate.NEW_CHAT_MEMBERS, restricted_to_allowed_chats(delete_bad_message)))
 
     application.add_error_handler(errors_logging)
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -9,6 +9,7 @@ from telegram.ext import Application, ChatMemberHandler, CommandHandler, Message
 
 from core.config import SENTRY_DSN, TELEGRAM_BOT_TOKEN
 from handlers.admin_handlers import ban_user, mute_user, unban_user, unmute_user
+from handlers.info_handlers import help_command, start
 from handlers.service_handlers import delete_bad_message, errors_logging, ping
 from handlers.user_handlers import greet_chat_members
 
@@ -23,6 +24,10 @@ def main() -> None:
 
     # Keep track of which chats the bot is in
     application.add_handler(CommandHandler("ping", ping))
+    # Greeting / private intro
+    application.add_handler(CommandHandler("start", start))
+    # Command and rules reference
+    application.add_handler(CommandHandler("help", help_command))
     # Ban user manual
     application.add_handler(CommandHandler("ban", ban_user))
     # Unban user manual

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -1,6 +1,8 @@
 ---
-groups:
-  main_group: '@jtprogru_chat'
+# Chats (numeric id or @username) where the bot is allowed to operate.
+# Anywhere else the bot stays silent and leaves the chat.
+allowed_chats:
+  - '@jtprogru_chat'
 
 moderation:
   # Delete the replied-to message when banning by reply.

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -2,3 +2,7 @@
 groups:
   main_group: '@jtprogru_chat'
 
+moderation:
+  # Delete the replied-to message when banning by reply.
+  delete_on_ban: true
+

--- a/src/core/allowlist.py
+++ b/src/core/allowlist.py
@@ -1,0 +1,69 @@
+import logging
+from functools import wraps
+
+from telegram.constants import ChatType
+from telegram.error import TelegramError
+
+from core.config import ALLOWED_CHATS
+
+logger = logging.getLogger(__name__)
+
+# Numeric chat ids the bot is allowed to operate in. Populated once at startup
+# by ``resolve_allowlist`` (see bot.py post_init). Empty until then.
+allowed_chat_ids: set[int] = set()
+
+
+def _looks_numeric(value: str) -> bool:
+    return value.lstrip("-").isdigit()
+
+
+async def resolve_allowlist(application) -> None:
+    """Resolve configured chats (ids or @usernames) to numeric ids once on start.
+
+    Numeric entries are used as-is; @username entries are resolved through the
+    Bot API. Anything that cannot be resolved is logged and skipped rather than
+    crashing the bot.
+    """
+    bot = application.bot
+    for entry in ALLOWED_CHATS:
+        if isinstance(entry, int):
+            allowed_chat_ids.add(entry)
+            continue
+        text = str(entry).strip()
+        if _looks_numeric(text):
+            allowed_chat_ids.add(int(text))
+            continue
+        try:
+            chat = await bot.get_chat(text)
+            allowed_chat_ids.add(chat.id)
+            logger.info("[INFO] Resolved allowed chat %s -> %s", text, chat.id)
+        except TelegramError as exc:
+            logger.warning("[WARN] Could not resolve allowed chat %s: %s", text, exc)
+    logger.info("[INFO] Allowed chat ids: %s", allowed_chat_ids)
+
+
+def restricted_to_allowed_chats(handler):
+    """Wrap a handler so it only runs in private DMs or allow-listed chats.
+
+    In any other group/supergroup the bot stays silent and leaves the chat, so a
+    single config is the only source of where the bot is active.
+    """
+
+    @wraps(handler)
+    async def wrapper(update, context, *args, **kwargs):
+        chat = update.effective_chat
+        if chat is None:
+            return None
+
+        # Direct messages are always allowed — that's where /start and /help live.
+        if chat.type == ChatType.PRIVATE or chat.id in allowed_chat_ids:
+            return await handler(update, context, *args, **kwargs)
+
+        logger.info("[INFO] Ignoring update from non-allowed chat %s (%s)", chat.id, chat.type)
+        try:
+            await chat.leave()
+        except TelegramError as exc:
+            logger.debug("[DEBUG] Could not leave non-allowed chat %s: %s", chat.id, exc)
+        return None
+
+    return wrapper

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -31,6 +31,9 @@ __load_cfg()
 TELEGRAM_BOT_TOKEN: Optional[str] = os.getenv("TELEGRAM_BOT_TOKEN")
 CHAT_RULES_URL: str = "https://jtprog.ru/chat-rules/"
 
+# Human-readable handle of the chat this bot serves, shown in /start and /help.
+MAIN_GROUP: str = cfg.get("groups", {}).get("main_group", "")
+
 DEBUG: bool = _parse_bool(os.getenv("DEBUG"))
 SENTRY_DSN: Optional[str] = os.getenv("SENTRY_DSN")
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -31,8 +31,11 @@ __load_cfg()
 TELEGRAM_BOT_TOKEN: Optional[str] = os.getenv("TELEGRAM_BOT_TOKEN")
 CHAT_RULES_URL: str = "https://jtprog.ru/chat-rules/"
 
+# Chats (numeric id or @username) the bot is allowed to operate in.
+ALLOWED_CHATS: list = list(cfg.get("allowed_chats", []) or [])
+
 # Human-readable handle of the chat this bot serves, shown in /start and /help.
-MAIN_GROUP: str = cfg.get("groups", {}).get("main_group", "")
+MAIN_GROUP: str = next((str(c) for c in ALLOWED_CHATS if str(c).startswith("@")), "")
 
 # Moderation behaviour toggles.
 DELETE_ON_BAN: bool = bool(cfg.get("moderation", {}).get("delete_on_ban", True))

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -34,6 +34,9 @@ CHAT_RULES_URL: str = "https://jtprog.ru/chat-rules/"
 # Human-readable handle of the chat this bot serves, shown in /start and /help.
 MAIN_GROUP: str = cfg.get("groups", {}).get("main_group", "")
 
+# Moderation behaviour toggles.
+DELETE_ON_BAN: bool = bool(cfg.get("moderation", {}).get("delete_on_ban", True))
+
 DEBUG: bool = _parse_bool(os.getenv("DEBUG"))
 SENTRY_DSN: Optional[str] = os.getenv("SENTRY_DSN")
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -8,6 +8,11 @@ from ruamel.yaml import YAML
 cfg = dict()
 yaml = YAML()
 
+# config.yaml lives next to the package root (src/config.yaml), one level up
+# from this module (src/core/). Resolving it relative to __file__ keeps loading
+# independent of the current working directory (local runs, Docker, pytest).
+_DEFAULT_CONFIG = os.path.join(os.path.dirname(os.path.dirname(__file__)), "config.yaml")
+
 
 def _parse_bool(value: Optional[str], default: bool = False) -> bool:
     if value is None:
@@ -15,7 +20,7 @@ def _parse_bool(value: Optional[str], default: bool = False) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def __load_cfg(configfile="config.yaml"):
+def __load_cfg(configfile=_DEFAULT_CONFIG):
     global cfg
     with open(configfile, "r") as fr:
         cfg = yaml.load(fr.read())

--- a/src/handlers/admin_handlers.py
+++ b/src/handlers/admin_handlers.py
@@ -3,7 +3,7 @@ from typing import Optional
 from telegram import ChatPermissions, Update, User
 from telegram.ext import ContextTypes
 
-from core.config import logger
+from core.config import DELETE_ON_BAN, logger
 
 MUTE_PERMISSIONS = ChatPermissions(
     can_send_messages=False,
@@ -87,6 +87,13 @@ async def ban_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     await update.effective_chat.ban_member(user_id=target.id)
     logger.info(f"[INFO] User with ID {target.id} was banned")
+
+    # Remove the offending message the ban was issued in reply to.
+    if DELETE_ON_BAN:
+        spam = update.effective_message.reply_to_message
+        if spam is not None:
+            await spam.delete()
+            logger.info(f"[INFO] Spam message {spam.message_id} from {target.id} was deleted")
 
 
 async def unban_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/src/handlers/admin_handlers.py
+++ b/src/handlers/admin_handlers.py
@@ -38,12 +38,13 @@ UNMUTE_PERMISSIONS = ChatPermissions(
 )
 
 
-async def _resolve_target(update: Update) -> Optional[User]:
+async def _resolve_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Optional[User]:
     """Validate an admin command and return the user it targets.
 
     The command must be sent by a chat administrator as a reply to the target
     user's message. Returns the target ``User`` or ``None`` if the command is
-    not applicable (not a reply, or the issuer is not an admin).
+    not applicable (not a reply, the issuer is not an admin, or the target is
+    protected — an administrator, the chat owner, or the bot itself).
     """
     message = update.effective_message
     chat = update.effective_chat
@@ -57,15 +58,30 @@ async def _resolve_target(update: Update) -> Optional[User]:
         return None
 
     admins = await chat.get_administrators()
-    if user.id not in {admin.user.id for admin in admins}:
+    admin_ids = {admin.user.id for admin in admins}
+    if user.id not in admin_ids:
         return None
 
-    return message.reply_to_message.from_user
+    target = message.reply_to_message.from_user
+    if target is None:
+        return None
+
+    # Protect privileged targets: never act on admins/owner or the bot itself,
+    # so an accidental reply+command gives a friendly notice instead of a
+    # silent Telegram rejection surfacing as a Sentry error.
+    if target.id == context.bot.id:
+        await message.reply_text("Меня самого модерировать не нужно 🙂")
+        return None
+    if target.id in admin_ids:
+        await message.reply_text("Нельзя применять модерацию к администратору или владельцу чата.")
+        return None
+
+    return target
 
 
 async def ban_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Ban the author of the replied-to message (admins only)."""
-    target = await _resolve_target(update)
+    target = await _resolve_target(update, context)
     if target is None:
         return
 
@@ -75,7 +91,7 @@ async def ban_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 async def unban_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Unban the author of the replied-to message (admins only)."""
-    target = await _resolve_target(update)
+    target = await _resolve_target(update, context)
     if target is None:
         return
 
@@ -85,7 +101,7 @@ async def unban_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
 
 async def mute_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Mute the author of the replied-to message (admins only)."""
-    target = await _resolve_target(update)
+    target = await _resolve_target(update, context)
     if target is None:
         return
 
@@ -95,7 +111,7 @@ async def mute_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 async def unmute_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Unmute the author of the replied-to message (admins only)."""
-    target = await _resolve_target(update)
+    target = await _resolve_target(update, context)
     if target is None:
         return
 

--- a/src/handlers/admin_handlers.py
+++ b/src/handlers/admin_handlers.py
@@ -29,9 +29,12 @@ UNMUTE_PERMISSIONS = ChatPermissions(
     can_send_videos=True,
     can_send_video_notes=True,
     can_send_voice_notes=True,
+    can_send_polls=True,
     can_send_other_messages=True,
     can_add_web_page_previews=True,
+    can_change_info=True,
     can_invite_users=True,
+    can_pin_messages=True,
 )
 
 

--- a/src/handlers/admin_handlers.py
+++ b/src/handlers/admin_handlers.py
@@ -1,6 +1,7 @@
-from typing import Optional
+from typing import Awaitable, Callable, Optional
 
 from telegram import ChatPermissions, Update, User
+from telegram.error import BadRequest, Forbidden
 from telegram.ext import ContextTypes
 
 from core.config import DELETE_ON_BAN, logger
@@ -79,21 +80,53 @@ async def _resolve_target(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     return target
 
 
+async def _apply_action(
+    update: Update,
+    action: Callable[[], Awaitable[object]],
+    success_text: str,
+) -> bool:
+    """Run a moderation ``action``, report the result, and clean up.
+
+    On success a short confirmation is posted in the chat and the command
+    message is removed so commands don't pile up. If the bot lacks the required
+    admin rights, the issuer gets a clear notice instead of a silent Telegram
+    rejection surfacing only as a Sentry error. Returns ``True`` on success.
+    """
+    message = update.effective_message
+    try:
+        await action()
+    except (BadRequest, Forbidden) as exc:
+        logger.warning("[WARN] Moderation action failed: %s", exc)
+        await message.reply_text("Не удалось выполнить команду: у меня нет нужных прав администратора в этом чате.")
+        return False
+
+    await message.reply_text(success_text)
+    try:
+        await message.delete()
+    except (BadRequest, Forbidden) as exc:
+        logger.debug("[DEBUG] Could not delete command message: %s", exc)
+    return True
+
+
 async def ban_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Ban the author of the replied-to message (admins only)."""
     target = await _resolve_target(update, context)
     if target is None:
         return
 
-    await update.effective_chat.ban_member(user_id=target.id)
+    chat = update.effective_chat
+    spam = update.effective_message.reply_to_message
+    if not await _apply_action(update, lambda: chat.ban_member(user_id=target.id), "🔨 Пользователь забанен."):
+        return
     logger.info(f"[INFO] User with ID {target.id} was banned")
 
     # Remove the offending message the ban was issued in reply to.
-    if DELETE_ON_BAN:
-        spam = update.effective_message.reply_to_message
-        if spam is not None:
+    if DELETE_ON_BAN and spam is not None:
+        try:
             await spam.delete()
             logger.info(f"[INFO] Spam message {spam.message_id} from {target.id} was deleted")
+        except (BadRequest, Forbidden) as exc:
+            logger.debug("[DEBUG] Could not delete spam message: %s", exc)
 
 
 async def unban_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -102,7 +135,9 @@ async def unban_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
     if target is None:
         return
 
-    await update.effective_chat.unban_member(user_id=target.id)
+    chat = update.effective_chat
+    if not await _apply_action(update, lambda: chat.unban_member(user_id=target.id), "✅ Пользователь разбанен."):
+        return
     logger.info(f"[INFO] User with ID {target.id} was unbanned")
 
 
@@ -112,7 +147,9 @@ async def mute_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if target is None:
         return
 
-    await update.effective_chat.restrict_member(user_id=target.id, permissions=MUTE_PERMISSIONS)
+    chat = update.effective_chat
+    if not await _apply_action(update, lambda: chat.restrict_member(user_id=target.id, permissions=MUTE_PERMISSIONS), "🔇 Пользователь замьючен."):
+        return
     logger.info(f"[INFO] User with ID {target.id} was muted")
 
 
@@ -122,5 +159,7 @@ async def unmute_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     if target is None:
         return
 
-    await update.effective_chat.restrict_member(user_id=target.id, permissions=UNMUTE_PERMISSIONS)
+    chat = update.effective_chat
+    if not await _apply_action(update, lambda: chat.restrict_member(user_id=target.id, permissions=UNMUTE_PERMISSIONS), "🔊 Пользователь размьючен."):
+        return
     logger.info(f"[INFO] User with ID {target.id} was unmuted")

--- a/src/handlers/info_handlers.py
+++ b/src/handlers/info_handlers.py
@@ -1,0 +1,59 @@
+import logging
+
+from telegram import LinkPreviewOptions, Update
+from telegram.constants import ChatType, ParseMode
+from telegram.ext import ContextTypes
+
+from core.config import CHAT_RULES_URL, MAIN_GROUP
+
+logger = logging.getLogger(__name__)
+
+# Commands every chat member can use.
+_USER_HELP = (
+    "<b>Я бот-модератор этого чата.</b>\n\n"
+    "Доступные команды:\n"
+    "• /help — это сообщение\n"
+    "• /ping — проверить, что бот жив\n\n"
+    f'Пожалуйста, прочитай <a href="{CHAT_RULES_URL}">правила чата</a>.'
+)
+
+# Extra block shown only to chat administrators.
+_ADMIN_HELP = (
+    "\n\n<b>Команды модерации (ответом на сообщение пользователя):</b>\n"
+    "• /ban — забанить автора\n"
+    "• /unban — разбанить автора\n"
+    "• /mute — замьютить автора\n"
+    "• /unmute — снять мьют с автора"
+)
+
+
+async def _is_chat_admin(update: Update) -> bool:
+    """Return True if the command issuer is an administrator of the chat."""
+    chat = update.effective_chat
+    user = update.effective_user
+    if chat is None or user is None or chat.type == ChatType.PRIVATE:
+        return False
+    admins = await chat.get_administrators()
+    return user.id in {admin.user.id for admin in admins}
+
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Briefly explain that this is a private moderation bot (mostly for DMs)."""
+    chat_ref = f" {MAIN_GROUP}" if MAIN_GROUP else ""
+    await update.effective_message.reply_text(
+        f"Привет! Я приватный бот-модератор чата{chat_ref}.\n\nВ личке я почти ничего не умею — вся работа происходит в чате. Список команд: /help",
+        parse_mode=ParseMode.HTML,
+        link_preview_options=LinkPreviewOptions(is_disabled=True),
+    )
+
+
+async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Show the command list; administrators additionally see moderation commands."""
+    text = _USER_HELP
+    if await _is_chat_admin(update):
+        text += _ADMIN_HELP
+    await update.effective_message.reply_text(
+        text,
+        parse_mode=ParseMode.HTML,
+        link_preview_options=LinkPreviewOptions(is_disabled=True),
+    )

--- a/tests/test_admin_permissions.py
+++ b/tests/test_admin_permissions.py
@@ -1,0 +1,38 @@
+from handlers.admin_handlers import MUTE_PERMISSIONS, UNMUTE_PERMISSIONS
+
+# Every chat permission the bot toggles on mute/unmute. Keeping this list
+# explicit makes the test fail loudly if PTB adds a new permission field that
+# the two objects forget to handle symmetrically.
+PERMISSION_FIELDS = (
+    "can_send_messages",
+    "can_send_audios",
+    "can_send_documents",
+    "can_send_photos",
+    "can_send_videos",
+    "can_send_video_notes",
+    "can_send_voice_notes",
+    "can_send_polls",
+    "can_send_other_messages",
+    "can_add_web_page_previews",
+    "can_change_info",
+    "can_invite_users",
+    "can_pin_messages",
+)
+
+
+def test_mute_disables_every_permission():
+    for field in PERMISSION_FIELDS:
+        assert getattr(MUTE_PERMISSIONS, field) is False, field
+
+
+def test_unmute_restores_every_permission():
+    for field in PERMISSION_FIELDS:
+        assert getattr(UNMUTE_PERMISSIONS, field) is True, field
+
+
+def test_mute_and_unmute_cover_the_same_fields():
+    # Unset ChatPermissions fields default to None; both objects must set the
+    # exact same set of fields so /unmute always cancels /mute symmetrically.
+    mute_set = {f for f in PERMISSION_FIELDS if getattr(MUTE_PERMISSIONS, f) is not None}
+    unmute_set = {f for f in PERMISSION_FIELDS if getattr(UNMUTE_PERMISSIONS, f) is not None}
+    assert mute_set == unmute_set == set(PERMISSION_FIELDS)

--- a/tests/test_admin_targets.py
+++ b/tests/test_admin_targets.py
@@ -15,13 +15,18 @@ class FakeAdmin:
 
 
 class FakeMessage:
-    def __init__(self, reply_to=None):
+    def __init__(self, reply_to=None, message_id=1):
         self.reply_to_message = reply_to
         self.from_user = None
+        self.message_id = message_id
         self.replies = []
+        self.deleted = False
 
     async def reply_text(self, text, **kwargs):
         self.replies.append(text)
+
+    async def delete(self):
+        self.deleted = True
 
 
 class FakeChat:

--- a/tests/test_admin_targets.py
+++ b/tests/test_admin_targets.py
@@ -1,0 +1,99 @@
+import asyncio
+
+import handlers.admin_handlers as admin
+
+
+class FakeUser:
+    def __init__(self, user_id, is_bot=False):
+        self.id = user_id
+        self.is_bot = is_bot
+
+
+class FakeAdmin:
+    def __init__(self, user):
+        self.user = user
+
+
+class FakeMessage:
+    def __init__(self, reply_to=None):
+        self.reply_to_message = reply_to
+        self.from_user = None
+        self.replies = []
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append(text)
+
+
+class FakeChat:
+    def __init__(self, admins):
+        self._admins = admins
+        self.banned = []
+        self.restricted = []
+
+    async def get_administrators(self):
+        return self._admins
+
+    async def ban_member(self, user_id):
+        self.banned.append(user_id)
+
+    async def restrict_member(self, user_id, permissions):
+        self.restricted.append(user_id)
+
+
+class FakeBot:
+    def __init__(self, bot_id):
+        self.id = bot_id
+
+
+class FakeContext:
+    def __init__(self, bot_id):
+        self.bot = FakeBot(bot_id)
+
+
+class FakeUpdate:
+    def __init__(self, message, chat, user):
+        self.effective_message = message
+        self.effective_chat = chat
+        self.effective_user = user
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make(issuer_id, target_user, admins, bot_id=999):
+    replied = FakeMessage()
+    replied.from_user = target_user
+    message = FakeMessage(reply_to=replied)
+    chat = FakeChat(admins)
+    update = FakeUpdate(message, chat, FakeUser(issuer_id))
+    return update, message, chat, FakeContext(bot_id)
+
+
+def test_ban_refuses_admin_target():
+    admin_user = FakeUser(7)
+    issuer = 5
+    admins = [FakeAdmin(FakeUser(issuer)), FakeAdmin(admin_user)]
+    update, message, chat, ctx = _make(issuer, admin_user, admins)
+    _run(admin.ban_user(update, ctx))
+    assert chat.banned == []
+    assert any("администратор" in r.lower() for r in message.replies)
+
+
+def test_ban_refuses_bot_itself():
+    bot_user = FakeUser(999, is_bot=True)
+    issuer = 5
+    admins = [FakeAdmin(FakeUser(issuer))]
+    update, message, chat, ctx = _make(issuer, bot_user, admins, bot_id=999)
+    _run(admin.ban_user(update, ctx))
+    assert chat.banned == []
+    assert message.replies
+
+
+def test_ban_allows_regular_user():
+    target = FakeUser(42)
+    issuer = 5
+    admins = [FakeAdmin(FakeUser(issuer))]
+    update, message, chat, ctx = _make(issuer, target, admins)
+    _run(admin.ban_user(update, ctx))
+    assert chat.banned == [42]

--- a/tests/test_allowlist.py
+++ b/tests/test_allowlist.py
@@ -1,0 +1,95 @@
+import asyncio
+
+import pytest
+from telegram.constants import ChatType
+from telegram.error import BadRequest
+
+import core.allowlist as allowlist
+
+
+class FakeChatInfo:
+    def __init__(self, chat_id):
+        self.id = chat_id
+
+
+class FakeBot:
+    def __init__(self, mapping):
+        self._mapping = mapping
+
+    async def get_chat(self, username):
+        if username not in self._mapping:
+            raise BadRequest("chat not found")
+        return FakeChatInfo(self._mapping[username])
+
+
+class FakeApplication:
+    def __init__(self, bot):
+        self.bot = bot
+
+
+class FakeChat:
+    def __init__(self, chat_id, chat_type=ChatType.SUPERGROUP):
+        self.id = chat_id
+        self.type = chat_type
+        self.left = False
+
+    async def leave(self):
+        self.left = True
+
+
+class FakeUpdate:
+    def __init__(self, chat):
+        self.effective_chat = chat
+
+
+@pytest.fixture(autouse=True)
+def _clear_ids():
+    allowlist.allowed_chat_ids.clear()
+    yield
+    allowlist.allowed_chat_ids.clear()
+
+
+def test_resolve_numeric_and_username(monkeypatch):
+    monkeypatch.setattr(allowlist, "ALLOWED_CHATS", [-100123, "12345", "@known", "@missing"])
+    app = FakeApplication(FakeBot({"@known": 777}))
+    asyncio.run(allowlist.resolve_allowlist(app))
+    assert allowlist.allowed_chat_ids == {-100123, 12345, 777}
+
+
+def test_guard_allows_private_chat():
+    calls = []
+
+    @allowlist.restricted_to_allowed_chats
+    async def handler(update, context):
+        calls.append(update.effective_chat.id)
+
+    update = FakeUpdate(FakeChat(1, ChatType.PRIVATE))
+    asyncio.run(handler(update, None))
+    assert calls == [1]
+
+
+def test_guard_allows_allowed_chat():
+    allowlist.allowed_chat_ids.add(555)
+    calls = []
+
+    @allowlist.restricted_to_allowed_chats
+    async def handler(update, context):
+        calls.append(update.effective_chat.id)
+
+    update = FakeUpdate(FakeChat(555))
+    asyncio.run(handler(update, None))
+    assert calls == [555]
+
+
+def test_guard_leaves_foreign_chat():
+    calls = []
+
+    @allowlist.restricted_to_allowed_chats
+    async def handler(update, context):
+        calls.append(update.effective_chat.id)
+
+    chat = FakeChat(999)
+    update = FakeUpdate(chat)
+    asyncio.run(handler(update, None))
+    assert calls == []
+    assert chat.left is True

--- a/tests/test_ban_delete.py
+++ b/tests/test_ban_delete.py
@@ -1,0 +1,80 @@
+import asyncio
+
+import handlers.admin_handlers as admin
+
+
+class FakeUser:
+    def __init__(self, user_id, is_bot=False):
+        self.id = user_id
+        self.is_bot = is_bot
+
+
+class FakeAdmin:
+    def __init__(self, user):
+        self.user = user
+
+
+class FakeMessage:
+    def __init__(self, reply_to=None, message_id=1):
+        self.reply_to_message = reply_to
+        self.from_user = None
+        self.message_id = message_id
+        self.replies = []
+        self.deleted = False
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append(text)
+
+    async def delete(self):
+        self.deleted = True
+
+
+class FakeChat:
+    def __init__(self, admins):
+        self._admins = admins
+        self.banned = []
+
+    async def get_administrators(self):
+        return self._admins
+
+    async def ban_member(self, user_id):
+        self.banned.append(user_id)
+
+
+class FakeContext:
+    class _Bot:
+        id = 999
+
+    bot = _Bot()
+
+
+class FakeUpdate:
+    def __init__(self, message, chat, user):
+        self.effective_message = message
+        self.effective_chat = chat
+        self.effective_user = user
+
+
+def _make(target_id=42, issuer_id=5):
+    spam = FakeMessage(message_id=100)
+    spam.from_user = FakeUser(target_id)
+    command = FakeMessage(reply_to=spam, message_id=101)
+    chat = FakeChat([FakeAdmin(FakeUser(issuer_id))])
+    update = FakeUpdate(command, chat, FakeUser(issuer_id))
+    return update, spam, chat
+
+
+def test_ban_deletes_spam_message_when_enabled(monkeypatch):
+    monkeypatch.setattr(admin, "DELETE_ON_BAN", True)
+    update, spam, chat = _make()
+    asyncio.run(admin.ban_user(update, FakeContext()))
+    assert chat.banned == [42]
+    assert spam.deleted is True
+
+
+def test_ban_keeps_spam_message_when_disabled(monkeypatch):
+    monkeypatch.setattr(admin, "DELETE_ON_BAN", False)
+    update, spam, chat = _make()
+    asyncio.run(admin.ban_user(update, FakeContext()))
+    assert chat.banned == [42]
+    assert spam.deleted is False

--- a/tests/test_command_feedback.py
+++ b/tests/test_command_feedback.py
@@ -1,0 +1,85 @@
+import asyncio
+
+from telegram.error import Forbidden
+
+import handlers.admin_handlers as admin
+
+
+class FakeUser:
+    def __init__(self, user_id, is_bot=False):
+        self.id = user_id
+        self.is_bot = is_bot
+
+
+class FakeAdmin:
+    def __init__(self, user):
+        self.user = user
+
+
+class FakeMessage:
+    def __init__(self, reply_to=None, message_id=1):
+        self.reply_to_message = reply_to
+        self.from_user = None
+        self.message_id = message_id
+        self.replies = []
+        self.deleted = False
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append(text)
+
+    async def delete(self):
+        self.deleted = True
+
+
+class FakeChat:
+    def __init__(self, admins, fail=False):
+        self._admins = admins
+        self._fail = fail
+        self.banned = []
+
+    async def get_administrators(self):
+        return self._admins
+
+    async def ban_member(self, user_id):
+        if self._fail:
+            raise Forbidden("not enough rights")
+        self.banned.append(user_id)
+
+
+class FakeContext:
+    class _Bot:
+        id = 999
+
+    bot = _Bot()
+
+
+class FakeUpdate:
+    def __init__(self, message, chat, user):
+        self.effective_message = message
+        self.effective_chat = chat
+        self.effective_user = user
+
+
+def _make(fail=False, target_id=42, issuer_id=5):
+    spam = FakeMessage(message_id=100)
+    spam.from_user = FakeUser(target_id)
+    command = FakeMessage(reply_to=spam, message_id=101)
+    chat = FakeChat([FakeAdmin(FakeUser(issuer_id))], fail=fail)
+    update = FakeUpdate(command, chat, FakeUser(issuer_id))
+    return update, command, chat
+
+
+def test_successful_ban_confirms_and_deletes_command():
+    update, command, chat = _make()
+    asyncio.run(admin.ban_user(update, FakeContext()))
+    assert chat.banned == [42]
+    assert command.replies  # confirmation posted
+    assert command.deleted is True  # command message cleaned up
+
+
+def test_missing_rights_reports_to_admin_and_keeps_command():
+    update, command, chat = _make(fail=True)
+    asyncio.run(admin.ban_user(update, FakeContext()))
+    assert chat.banned == []
+    assert any("прав" in r.lower() for r in command.replies)
+    assert command.deleted is False

--- a/tests/test_info_handlers.py
+++ b/tests/test_info_handlers.py
@@ -1,0 +1,66 @@
+import asyncio
+
+import handlers.info_handlers as info
+
+
+class FakeMessage:
+    def __init__(self):
+        self.replies = []
+
+    async def reply_text(self, text, **kwargs):
+        self.replies.append(text)
+
+
+class FakeUser:
+    def __init__(self, user_id):
+        self.id = user_id
+
+
+class FakeAdmin:
+    def __init__(self, user):
+        self.user = user
+
+
+class FakeChat:
+    def __init__(self, chat_type, admins=()):
+        self.type = chat_type
+        self._admins = admins
+
+    async def get_administrators(self):
+        return self._admins
+
+
+class FakeUpdate:
+    def __init__(self, message, chat, user):
+        self.effective_message = message
+        self.effective_chat = chat
+        self.effective_user = user
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_start_mentions_private_bot():
+    msg = FakeMessage()
+    update = FakeUpdate(msg, FakeChat("private"), FakeUser(1))
+    _run(info.start(update, None))
+    assert msg.replies and "приватный" in msg.replies[0].lower()
+
+
+def test_help_for_regular_user_has_no_moderation_block():
+    user = FakeUser(7)
+    msg = FakeMessage()
+    update = FakeUpdate(msg, FakeChat("supergroup", admins=[]), user)
+    _run(info.help_command(update, None))
+    assert "/ban" not in msg.replies[0]
+    assert "/ping" in msg.replies[0]
+
+
+def test_help_for_admin_includes_moderation_block():
+    user = FakeUser(7)
+    msg = FakeMessage()
+    chat = FakeChat("supergroup", admins=[FakeAdmin(FakeUser(7))])
+    update = FakeUpdate(msg, chat, user)
+    _run(info.help_command(update, None))
+    assert "/ban" in msg.replies[0]


### PR DESCRIPTION
## Фаза 0 ROADMAP — хардненинг и быстрые правки

Закрывает все шесть issue Фазы 0. Каждый пункт — отдельный атомарный коммит.

| Коммит | Issue | Суть |
|---|---|---|
| `/unmute` | #73 · 0.2 | восстановление полных прав (симметрия с `MUTE`) + тест на симметрию |
| `/help`, `/start` | #77 · 0.6 | список команд (расширенный для админов) и интро в личке |
| Защита целей | #76 · 0.5 | нельзя модерировать админа/владельца/бота — дружелюбный отказ |
| `/ban` чистит спам | #75 · 0.4 | удаление reply-сообщения; настройка `moderation.delete_on_ban` |
| Фидбэк команд | #74 · 0.3 | подтверждение в чате, удаление команды, отказ при нехватке прав |
| Allowlist чатов | #72 · 0.1 | `allowed_chats` из конфига, резолв `@username→id`, гард на всех хендлерах |

### Заметки
- `0.2` дополнительно сделал загрузку `config.yaml` независимой от CWD (путь относительно модуля) — без этого пакет не импортировался в pytest из корня репозитория.
- Гард `restricted_to_allowed_chats` пропускает личку (для `/start` и `/help`) и разрешённые чаты; в чужом групповом чате бот молчит и выходит (`leave_chat`).

### Тесты
Покрытие выросло с 7 до 24 тестов. Локально: `24 passed`, `ruff` чистый, `bot.py` импортируется.

Closes #72, #73, #74, #75, #76, #77