### PR TITLE
feat: 2.3 Состояние/БД — слой хранения на SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ venv/
 __pycache__/
 .pytest_cache/
 .env
+
+# SQLite state (and WAL/SHM sidecars)
+*.db
+*.db-wal
+*.db-shm

--- a/.k8s/deployment.yaml
+++ b/.k8s/deployment.yaml
@@ -1,3 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: py-tg-moder-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 256Mi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -7,6 +18,9 @@ spec:
     matchLabels:
       app: py-tg-moder
   replicas: 1
+  # Single replica owns the SQLite file; recreate (don't run two pods at once).
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -22,6 +36,14 @@ spec:
               secretKeyRef:
                 name: py-tg-moder-secret
                 key: tg_token
+          - name: DB_PATH
+            value: /data/moder.db
+        volumeMounts:
+          - name: data
+            mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: py-tg-moder-data
       imagePullSecrets:
       - name: ghcrio-auth-secret
-

--- a/src/bot.py
+++ b/src/bot.py
@@ -9,6 +9,7 @@ from telegram.ext import Application, ChatMemberHandler, CommandHandler, Message
 
 from core.allowlist import resolve_allowlist, restricted_to_allowed_chats
 from core.config import SENTRY_DSN, TELEGRAM_BOT_TOKEN
+from core.storage import get_storage
 from handlers.admin_handlers import ban_user, mute_user, unban_user, unmute_user
 from handlers.info_handlers import help_command, start
 from handlers.service_handlers import delete_bad_message, errors_logging, ping
@@ -20,6 +21,10 @@ logger = logging.getLogger(__name__)
 
 def main() -> None:
     sentry_sdk.init(SENTRY_DSN, traces_sample_rate=1.0)
+
+    # Open the database and create the schema before any update is handled.
+    storage = get_storage()
+    logger.info("[INFO] Storage ready at %s", storage.path)
 
     # Resolve the configured allowlist (@usernames -> ids) once the bot is ready.
     application = Application.builder().token(TELEGRAM_BOT_TOKEN).post_init(resolve_allowlist).build()

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -8,3 +8,8 @@ moderation:
   # Delete the replied-to message when banning by reply.
   delete_on_ban: true
 
+storage:
+  # SQLite database file for moderation state. Overridden by the DB_PATH env var.
+  # Point this at a mounted volume so state survives restarts.
+  path: 'moder.db'
+

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -40,6 +40,11 @@ MAIN_GROUP: str = next((str(c) for c in ALLOWED_CHATS if str(c).startswith("@"))
 # Moderation behaviour toggles.
 DELETE_ON_BAN: bool = bool(cfg.get("moderation", {}).get("delete_on_ban", True))
 
+# Path to the SQLite database that holds moderation state (warns, mutes, stats).
+# Env DB_PATH wins over config.yaml so deployments can point it at a mounted
+# volume without touching the image.
+DB_PATH: str = os.getenv("DB_PATH") or str(cfg.get("storage", {}).get("path", "moder.db"))
+
 DEBUG: bool = _parse_bool(os.getenv("DEBUG"))
 SENTRY_DSN: Optional[str] = os.getenv("SENTRY_DSN")
 

--- a/src/core/storage.py
+++ b/src/core/storage.py
@@ -1,0 +1,291 @@
+# -*- coding: utf-8 -*-
+"""SQLite persistence layer.
+
+A thin repository over a single SQLite database so handlers never touch SQL
+directly. The store keeps moderation state that must survive a bot restart:
+member activity ("newness" + stats), warns, active mutes and free-form
+counters.
+
+The repository is synchronous; async handlers should call it through
+``asyncio.to_thread`` (the same pattern the CAS client already uses). The
+connection is opened with ``check_same_thread=False`` and guarded by a lock so
+it is safe to use from the thread pool.
+"""
+
+import os
+import sqlite3
+import threading
+import time
+from typing import Optional
+
+from core.config import DB_PATH
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS members (
+    chat_id       INTEGER NOT NULL,
+    user_id       INTEGER NOT NULL,
+    first_seen    INTEGER NOT NULL,
+    last_seen     INTEGER NOT NULL,
+    message_count INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (chat_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS warns (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    chat_id       INTEGER NOT NULL,
+    user_id       INTEGER NOT NULL,
+    moderator_id  INTEGER,
+    reason        TEXT,
+    created_at    INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_warns_chat_user ON warns (chat_id, user_id);
+
+CREATE TABLE IF NOT EXISTS mutes (
+    chat_id     INTEGER NOT NULL,
+    user_id     INTEGER NOT NULL,
+    until       INTEGER,
+    created_at  INTEGER NOT NULL,
+    PRIMARY KEY (chat_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS counters (
+    chat_id INTEGER NOT NULL,
+    name    TEXT NOT NULL,
+    value   INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (chat_id, name)
+);
+"""
+
+
+def _now(now: Optional[int]) -> int:
+    return int(time.time()) if now is None else now
+
+
+class Storage:
+    """Repository over a SQLite database."""
+
+    def __init__(self, path: str):
+        self.path = path
+        if path != ":memory:":
+            parent = os.path.dirname(path)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+        self._conn = sqlite3.connect(path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._lock = threading.Lock()
+        self._init_schema()
+
+    def _init_schema(self) -> None:
+        with self._lock:
+            if self.path != ":memory:":
+                # Better read/write concurrency for a long-running process.
+                self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.executescript(_SCHEMA)
+            self._conn.commit()
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    # -- members: "newness" + activity stats -----------------------------------
+
+    def record_member(self, chat_id: int, user_id: int, now: Optional[int] = None) -> None:
+        """Remember when a user was first seen in a chat (no-op if already known)."""
+        ts = _now(now)
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO members (chat_id, user_id, first_seen, last_seen) VALUES (?, ?, ?, ?) ON CONFLICT(chat_id, user_id) DO NOTHING",
+                (chat_id, user_id, ts, ts),
+            )
+            self._conn.commit()
+
+    def touch_member(self, chat_id: int, user_id: int, now: Optional[int] = None) -> int:
+        """Count a message from a user, returning the new message count."""
+        ts = _now(now)
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO members (chat_id, user_id, first_seen, last_seen, message_count) "
+                "VALUES (?, ?, ?, ?, 1) "
+                "ON CONFLICT(chat_id, user_id) DO UPDATE SET "
+                "last_seen = excluded.last_seen, message_count = message_count + 1",
+                (chat_id, user_id, ts, ts),
+            )
+            row = self._conn.execute(
+                "SELECT message_count FROM members WHERE chat_id = ? AND user_id = ?",
+                (chat_id, user_id),
+            ).fetchone()
+            self._conn.commit()
+        return row["message_count"]
+
+    def get_member(self, chat_id: int, user_id: int) -> Optional[dict]:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT chat_id, user_id, first_seen, last_seen, message_count FROM members WHERE chat_id = ? AND user_id = ?",
+                (chat_id, user_id),
+            ).fetchone()
+        return dict(row) if row else None
+
+    def is_new_member(
+        self,
+        chat_id: int,
+        user_id: int,
+        max_messages: int = 5,
+        max_age_seconds: int = 86400,
+        now: Optional[int] = None,
+    ) -> bool:
+        """Treat unknown users and users still within their grace window as new.
+
+        A user is "new" until they have either sent ``max_messages`` messages or
+        been known for ``max_age_seconds`` — whichever comes first.
+        """
+        member = self.get_member(chat_id, user_id)
+        if member is None:
+            return True
+        if member["message_count"] >= max_messages:
+            return False
+        return _now(now) - member["first_seen"] < max_age_seconds
+
+    # -- warns -----------------------------------------------------------------
+
+    def add_warn(
+        self,
+        chat_id: int,
+        user_id: int,
+        moderator_id: Optional[int] = None,
+        reason: Optional[str] = None,
+        now: Optional[int] = None,
+    ) -> int:
+        with self._lock:
+            cur = self._conn.execute(
+                "INSERT INTO warns (chat_id, user_id, moderator_id, reason, created_at) VALUES (?, ?, ?, ?, ?)",
+                (chat_id, user_id, moderator_id, reason, _now(now)),
+            )
+            self._conn.commit()
+            return cur.lastrowid
+
+    def count_warns(self, chat_id: int, user_id: int) -> int:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT COUNT(*) AS n FROM warns WHERE chat_id = ? AND user_id = ?",
+                (chat_id, user_id),
+            ).fetchone()
+        return row["n"]
+
+    def list_warns(self, chat_id: int, user_id: int) -> list[dict]:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT id, chat_id, user_id, moderator_id, reason, created_at FROM warns WHERE chat_id = ? AND user_id = ? ORDER BY id",
+                (chat_id, user_id),
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def remove_last_warn(self, chat_id: int, user_id: int) -> bool:
+        """Drop the most recent warn for a user; return True if one was removed."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT id FROM warns WHERE chat_id = ? AND user_id = ? ORDER BY id DESC LIMIT 1",
+                (chat_id, user_id),
+            ).fetchone()
+            if row is None:
+                return False
+            self._conn.execute("DELETE FROM warns WHERE id = ?", (row["id"],))
+            self._conn.commit()
+        return True
+
+    def clear_warns(self, chat_id: int, user_id: int) -> int:
+        """Remove all warns for a user; return how many were removed."""
+        with self._lock:
+            cur = self._conn.execute(
+                "DELETE FROM warns WHERE chat_id = ? AND user_id = ?",
+                (chat_id, user_id),
+            )
+            self._conn.commit()
+            return cur.rowcount
+
+    # -- mutes -----------------------------------------------------------------
+
+    def add_mute(
+        self,
+        chat_id: int,
+        user_id: int,
+        until: Optional[int] = None,
+        now: Optional[int] = None,
+    ) -> None:
+        """Record an active mute. ``until`` is a unix timestamp, or None for indefinite."""
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO mutes (chat_id, user_id, until, created_at) VALUES (?, ?, ?, ?) "
+                "ON CONFLICT(chat_id, user_id) DO UPDATE SET until = excluded.until, created_at = excluded.created_at",
+                (chat_id, user_id, until, _now(now)),
+            )
+            self._conn.commit()
+
+    def remove_mute(self, chat_id: int, user_id: int) -> bool:
+        with self._lock:
+            cur = self._conn.execute(
+                "DELETE FROM mutes WHERE chat_id = ? AND user_id = ?",
+                (chat_id, user_id),
+            )
+            self._conn.commit()
+        return cur.rowcount > 0
+
+    def is_muted(self, chat_id: int, user_id: int, now: Optional[int] = None) -> bool:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT until FROM mutes WHERE chat_id = ? AND user_id = ?",
+                (chat_id, user_id),
+            ).fetchone()
+        if row is None:
+            return False
+        return row["until"] is None or row["until"] > _now(now)
+
+    def get_active_mutes(self, now: Optional[int] = None) -> list[dict]:
+        """Return mutes that are still in effect (used to rearm timers on startup)."""
+        ts = _now(now)
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT chat_id, user_id, until, created_at FROM mutes WHERE until IS NULL OR until > ? ORDER BY chat_id, user_id",
+                (ts,),
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    # -- counters / stats ------------------------------------------------------
+
+    def increment_counter(self, chat_id: int, name: str, amount: int = 1) -> int:
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO counters (chat_id, name, value) VALUES (?, ?, ?) ON CONFLICT(chat_id, name) DO UPDATE SET value = value + excluded.value",
+                (chat_id, name, amount),
+            )
+            row = self._conn.execute(
+                "SELECT value FROM counters WHERE chat_id = ? AND name = ?",
+                (chat_id, name),
+            ).fetchone()
+            self._conn.commit()
+        return row["value"]
+
+    def get_counter(self, chat_id: int, name: str) -> int:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT value FROM counters WHERE chat_id = ? AND name = ?",
+                (chat_id, name),
+            ).fetchone()
+        return row["value"] if row else 0
+
+
+_storage: Optional[Storage] = None
+_storage_lock = threading.Lock()
+
+
+def get_storage() -> Storage:
+    """Return the process-wide storage, creating it on first use.
+
+    Lazy so importing this module has no side effects (no DB file is created
+    until something actually needs the store).
+    """
+    global _storage
+    if _storage is None:
+        with _storage_lock:
+            if _storage is None:
+                _storage = Storage(DB_PATH)
+    return _storage

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,133 @@
+import pytest
+
+from core.storage import Storage
+
+
+@pytest.fixture
+def store():
+    s = Storage(":memory:")
+    yield s
+    s.close()
+
+
+# -- members ---------------------------------------------------------------
+
+
+def test_record_member_is_idempotent(store):
+    store.record_member(1, 42, now=100)
+    store.record_member(1, 42, now=200)  # must not overwrite first_seen
+    member = store.get_member(1, 42)
+    assert member["first_seen"] == 100
+    assert member["message_count"] == 0
+
+
+def test_touch_member_counts_messages(store):
+    assert store.touch_member(1, 42, now=100) == 1
+    assert store.touch_member(1, 42, now=110) == 2
+    member = store.get_member(1, 42)
+    assert member["message_count"] == 2
+    assert member["last_seen"] == 110
+    assert member["first_seen"] == 100
+
+
+def test_is_new_member_unknown_user(store):
+    assert store.is_new_member(1, 999) is True
+
+
+def test_is_new_member_graduates_by_message_count(store):
+    for ts in range(5):
+        store.touch_member(1, 42, now=100 + ts)
+    assert store.is_new_member(1, 42, max_messages=5, now=101) is False
+
+
+def test_is_new_member_graduates_by_age(store):
+    store.touch_member(1, 42, now=100)
+    assert store.is_new_member(1, 42, max_messages=5, max_age_seconds=10, now=105) is True
+    assert store.is_new_member(1, 42, max_messages=5, max_age_seconds=10, now=200) is False
+
+
+# -- warns -----------------------------------------------------------------
+
+
+def test_warns_add_count_list(store):
+    store.add_warn(1, 42, moderator_id=7, reason="spam", now=100)
+    store.add_warn(1, 42, moderator_id=7, reason="flood", now=200)
+    assert store.count_warns(1, 42) == 2
+    reasons = [w["reason"] for w in store.list_warns(1, 42)]
+    assert reasons == ["spam", "flood"]
+
+
+def test_remove_last_warn(store):
+    store.add_warn(1, 42, reason="a", now=100)
+    store.add_warn(1, 42, reason="b", now=200)
+    assert store.remove_last_warn(1, 42) is True
+    assert [w["reason"] for w in store.list_warns(1, 42)] == ["a"]
+    assert store.remove_last_warn(1, 99) is False
+
+
+def test_clear_warns(store):
+    store.add_warn(1, 42, now=100)
+    store.add_warn(1, 42, now=200)
+    assert store.clear_warns(1, 42) == 2
+    assert store.count_warns(1, 42) == 0
+
+
+# -- mutes -----------------------------------------------------------------
+
+
+def test_mute_active_and_expired(store):
+    store.add_mute(1, 42, until=500, now=100)
+    assert store.is_muted(1, 42, now=300) is True
+    assert store.is_muted(1, 42, now=600) is False
+
+
+def test_indefinite_mute(store):
+    store.add_mute(1, 42, until=None, now=100)
+    assert store.is_muted(1, 42, now=10**9) is True
+
+
+def test_remove_mute(store):
+    store.add_mute(1, 42, until=500, now=100)
+    assert store.remove_mute(1, 42) is True
+    assert store.is_muted(1, 42, now=300) is False
+    assert store.remove_mute(1, 42) is False
+
+
+def test_get_active_mutes_filters_expired(store):
+    store.add_mute(1, 1, until=500, now=100)
+    store.add_mute(1, 2, until=None, now=100)
+    store.add_mute(1, 3, until=200, now=100)
+    active = {m["user_id"] for m in store.get_active_mutes(now=300)}
+    assert active == {1, 2}
+
+
+# -- counters --------------------------------------------------------------
+
+
+def test_counters(store):
+    assert store.get_counter(1, "bans") == 0
+    assert store.increment_counter(1, "bans") == 1
+    assert store.increment_counter(1, "bans", amount=2) == 3
+    assert store.get_counter(1, "bans") == 3
+
+
+# -- persistence across reconnect (the actual restart criterion) -----------
+
+
+def test_state_survives_reconnect(tmp_path):
+    db = str(tmp_path / "moder.db")
+
+    first = Storage(db)
+    first.add_warn(1, 42, reason="spam", now=100)
+    first.add_mute(1, 42, until=None, now=100)
+    first.increment_counter(1, "bans", amount=4)
+    first.touch_member(1, 42, now=100)
+    first.close()
+
+    # Reopen as if the bot restarted.
+    second = Storage(db)
+    assert second.count_warns(1, 42) == 1
+    assert second.is_muted(1, 42, now=10**9) is True
+    assert second.get_counter(1, "bans") == 4
+    assert second.get_member(1, 42)["message_count"] == 1
+    second.close()


### PR DESCRIPTION
## Фаза 2 · 2.3 — Состояние / БД (SQLite)

Фундамент для модерации с памятью: варны/мьюты/статистика теперь переживают рестарт. Хендлеры от деталей БД изолированы.

### Что добавлено
- **`core/storage.py`** — репозиторий `Storage` поверх SQLite. Таблицы:
  - `members` — «новизна» (first_seen, message_count) и активность для статистики (для #78);
  - `warns` — история варнов с причиной и модератором (для #83);
  - `mutes` — активные мьюты с `until` для восстановления таймеров после рестарта (для #81/#82);
  - `counters` — произвольные счётчики статистики.
- Репозиторий **синхронный и потокобезопасный** (одно соединение под `Lock`, `check_same_thread=False`, WAL) — async-хендлеры будут вызывать его через `asyncio.to_thread`, как уже сделано для CAS.
- Синглтон `get_storage()` **ленивый** — импорт модуля не создаёт файл БД (без побочных эффектов в тестах).
- Путь к БД: `DB_PATH` (env) → `storage.path` в `config.yaml` → дефолт `moder.db`. Схема создаётся на старте в `bot.py`.

### Persistence в k8s
Деплой был stateless. Добавлен **PVC** (RWO, 256Mi) в `/data`, `DB_PATH=/data/moder.db`, стратегия обновления — **Recreate** (один под владеет файлом SQLite).

### Тесты
+15 тестов: CRUD по всем таблицам, логика «новизны» (по числу сообщений и по возрасту), активные/истёкшие мьюты, и ключевой тест — **состояние переживает reconnect** (эмуляция рестарта). Локально: `38 passed`, `ruff format --check` + `ruff check` чистые.

### Scope
PR закладывает фундамент; подключение к реальным командам — в зависимых issue (#78, #83, #81, #85).

Closes #84