### PR TITLE
feat: 1.1 Модерация сообщений от новичков

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -12,6 +12,7 @@ from core.config import SENTRY_DSN, TELEGRAM_BOT_TOKEN
 from core.storage import get_storage
 from handlers.admin_handlers import ban_user, mute_user, unban_user, unmute_user
 from handlers.info_handlers import help_command, start
+from handlers.message_moderation import moderate_message
 from handlers.service_handlers import delete_bad_message, errors_logging, ping
 from handlers.user_handlers import greet_chat_members
 from handlers.warn_handlers import unwarn_user, warn_user, warns_list
@@ -52,6 +53,14 @@ def main() -> None:
     application.add_handler(CommandHandler("warns", restricted_to_allowed_chats(warns_list)))
     # Remove a user's last warn
     application.add_handler(CommandHandler("unwarn", restricted_to_allowed_chats(unwarn_user)))
+
+    # Filter links/forwards/mentions from newcomers (also re-checks edits)
+    application.add_handler(
+        MessageHandler(
+            (filters.TEXT | filters.CAPTION | filters.FORWARDED) & ~filters.COMMAND,
+            restricted_to_allowed_chats(moderate_message),
+        )
+    )
 
     # Welcome message
     application.add_handler(ChatMemberHandler(restricted_to_allowed_chats(greet_chat_members), ChatMemberHandler.CHAT_MEMBER))

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -10,6 +10,17 @@ moderation:
   # Number of warns before an automatic punishment, and what it does (mute|ban).
   warn_limit: 3
   warn_action: mute
+  # Content filter for messages from newcomers (also re-checks edited messages).
+  newcomer_filter:
+    enabled: true
+    # A user is a "newcomer" until they hit either threshold (whichever first).
+    max_messages: 5
+    max_age_seconds: 86400
+    # What to do on a hit: delete | mute | warn.
+    action: delete
+    block_links: true
+    block_forwards: true
+    block_mentions: true
 
 storage:
   # SQLite database file for moderation state. Overridden by the DB_PATH env var.

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -45,6 +45,17 @@ WARN_LIMIT: int = int(cfg.get("moderation", {}).get("warn_limit", 3))
 _warn_action: str = str(cfg.get("moderation", {}).get("warn_action", "mute")).lower()
 WARN_ACTION: str = _warn_action if _warn_action in {"mute", "ban"} else "mute"
 
+# Content filter for messages from newcomers (links/forwards/mentions/invites).
+_newcomer: dict = cfg.get("moderation", {}).get("newcomer_filter", {}) or {}
+NEWCOMER_FILTER_ENABLED: bool = bool(_newcomer.get("enabled", True))
+NEWCOMER_MAX_MESSAGES: int = int(_newcomer.get("max_messages", 5))
+NEWCOMER_MAX_AGE: int = int(_newcomer.get("max_age_seconds", 86400))
+_newcomer_action: str = str(_newcomer.get("action", "delete")).lower()
+NEWCOMER_ACTION: str = _newcomer_action if _newcomer_action in {"delete", "mute", "warn"} else "delete"
+NEWCOMER_BLOCK_LINKS: bool = bool(_newcomer.get("block_links", True))
+NEWCOMER_BLOCK_FORWARDS: bool = bool(_newcomer.get("block_forwards", True))
+NEWCOMER_BLOCK_MENTIONS: bool = bool(_newcomer.get("block_mentions", True))
+
 # Path to the SQLite database that holds moderation state (warns, mutes, stats).
 # Env DB_PATH wins over config.yaml so deployments can point it at a mounted
 # volume without touching the image.

--- a/src/handlers/message_moderation.py
+++ b/src/handlers/message_moderation.py
@@ -1,0 +1,117 @@
+"""Content moderation for messages from newcomers.
+
+New users (within their first N messages / first day) get their links,
+forwards, @-mentions and Telegram invites filtered. Edited messages are
+re-checked automatically — python-telegram-bot content filters also match
+``edited_message`` — closing the "clean text, then edit into spam" trick.
+"""
+
+import asyncio
+from typing import Optional
+
+from telegram import Message, MessageEntity, Update
+from telegram.error import BadRequest, Forbidden
+from telegram.ext import ContextTypes
+
+from core import config
+from core.config import logger
+from core.storage import get_storage
+
+from .admin_handlers import MUTE_PERMISSIONS
+from .warn_handlers import _auto_punish
+
+
+def _is_telegram_invite(url: str) -> bool:
+    low = url.lower()
+    return ("t.me/+" in low) or ("t.me/joinchat" in low) or ("telegram.me/joinchat" in low)
+
+
+def find_violation(message: Message) -> Optional[str]:
+    """Return a short reason if the message breaks a newcomer rule, else None."""
+    if config.NEWCOMER_BLOCK_FORWARDS and message.forward_origin is not None:
+        return "форвард"
+
+    entities = list(message.entities or []) + list(message.caption_entities or [])
+    text = message.text or message.caption or ""
+
+    if config.NEWCOMER_BLOCK_LINKS:
+        for entity in entities:
+            if entity.type in (MessageEntity.URL, MessageEntity.TEXT_LINK):
+                url = entity.url or text[entity.offset : entity.offset + entity.length]
+                return "telegram-инвайт" if _is_telegram_invite(url) else "ссылка"
+
+    if config.NEWCOMER_BLOCK_MENTIONS:
+        for entity in entities:
+            if entity.type in (MessageEntity.MENTION, MessageEntity.TEXT_MENTION):
+                return "@-упоминание"
+
+    return None
+
+
+async def _enforce(update: Update, context: ContextTypes.DEFAULT_TYPE, user_id: int, reason: str) -> None:
+    """Delete the offending message and apply the configured action."""
+    chat = update.effective_chat
+    message = update.effective_message
+    storage = get_storage()
+
+    try:
+        await message.delete()
+    except (BadRequest, Forbidden) as exc:
+        logger.debug("[DEBUG] Could not delete newcomer message: %s", exc)
+
+    await asyncio.to_thread(storage.increment_counter, chat.id, "newcomer_filtered")
+
+    if config.NEWCOMER_ACTION == "mute":
+        try:
+            await chat.restrict_member(user_id=user_id, permissions=MUTE_PERMISSIONS)
+            await asyncio.to_thread(storage.add_mute, chat.id, user_id, None)
+        except (BadRequest, Forbidden) as exc:
+            logger.warning("[WARN] Could not mute newcomer %s: %s", user_id, exc)
+    elif config.NEWCOMER_ACTION == "warn":
+        await asyncio.to_thread(storage.add_warn, chat.id, user_id, context.bot.id, f"авто: {reason}")
+        count = await asyncio.to_thread(storage.count_warns, chat.id, user_id)
+        if count >= config.WARN_LIMIT:
+            await _auto_punish(update, user_id)
+            await asyncio.to_thread(storage.clear_warns, chat.id, user_id)
+
+    logger.info("[INFO] Newcomer %s message filtered (%s, action=%s)", user_id, reason, config.NEWCOMER_ACTION)
+
+
+async def moderate_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Filter newcomer messages; re-runs on edits to catch post-hoc spam."""
+    if not config.NEWCOMER_FILTER_ENABLED:
+        return
+
+    message = update.effective_message
+    chat = update.effective_chat
+    user = update.effective_user
+    if message is None or chat is None or user is None or user.is_bot:
+        return
+
+    storage = get_storage()
+    is_edit = update.edited_message is not None
+
+    # Decide newness from stored state first, then count fresh (not edits) messages.
+    is_new = await asyncio.to_thread(
+        storage.is_new_member,
+        chat.id,
+        user.id,
+        config.NEWCOMER_MAX_MESSAGES,
+        config.NEWCOMER_MAX_AGE,
+    )
+    if not is_edit:
+        await asyncio.to_thread(storage.touch_member, chat.id, user.id)
+
+    if not is_new:
+        return
+
+    reason = find_violation(message)
+    if reason is None:
+        return
+
+    # Acting is rare, so the admin lookup here stays cheap; never touch admins.
+    admins = await chat.get_administrators()
+    if user.id in {admin.user.id for admin in admins}:
+        return
+
+    await _enforce(update, context, user.id, reason)

--- a/tests/test_message_moderation.py
+++ b/tests/test_message_moderation.py
@@ -1,0 +1,186 @@
+import asyncio
+
+import pytest
+from telegram import MessageEntity
+
+import handlers.message_moderation as mod
+import handlers.warn_handlers as warns
+from core import config
+from core.storage import Storage
+
+
+class FakeMessage:
+    def __init__(self, text="", entities=None, caption=None, caption_entities=None, forward_origin=None):
+        self.text = text
+        self.caption = caption
+        self.entities = entities or []
+        self.caption_entities = caption_entities or []
+        self.forward_origin = forward_origin
+        self.deleted = False
+
+    async def delete(self):
+        self.deleted = True
+
+
+class FakeUser:
+    def __init__(self, user_id, is_bot=False):
+        self.id = user_id
+        self.is_bot = is_bot
+
+    def mention_html(self):
+        return f"user:{self.id}"
+
+
+class FakeAdmin:
+    def __init__(self, user):
+        self.user = user
+
+
+class FakeChat:
+    def __init__(self, chat_id, admins=()):
+        self.id = chat_id
+        self._admins = list(admins)
+        self.restricted = []
+        self.banned = []
+
+    async def get_administrators(self):
+        return self._admins
+
+    async def restrict_member(self, user_id, permissions):
+        self.restricted.append(user_id)
+
+    async def ban_member(self, user_id):
+        self.banned.append(user_id)
+
+
+class FakeContext:
+    class _Bot:
+        id = 999
+
+    bot = _Bot()
+
+
+class FakeUpdate:
+    def __init__(self, message, chat, user, edited=False):
+        self.effective_message = message
+        self.effective_chat = chat
+        self.effective_user = user
+        self.edited_message = message if edited else None
+
+
+@pytest.fixture
+def store(monkeypatch):
+    s = Storage(":memory:")
+    monkeypatch.setattr(mod, "get_storage", lambda: s)
+    monkeypatch.setattr(warns, "get_storage", lambda: s)
+    yield s
+    s.close()
+
+
+# -- find_violation (pure) -------------------------------------------------
+
+
+def test_violation_plain_link():
+    msg = FakeMessage(text="http://spam.com", entities=[MessageEntity(type=MessageEntity.URL, offset=0, length=15)])
+    assert mod.find_violation(msg) == "ссылка"
+
+
+def test_violation_telegram_invite():
+    msg = FakeMessage(text="join", entities=[MessageEntity(type=MessageEntity.TEXT_LINK, offset=0, length=4, url="https://t.me/+abcd")])
+    assert mod.find_violation(msg) == "telegram-инвайт"
+
+
+def test_violation_mention():
+    msg = FakeMessage(text="@someone hi", entities=[MessageEntity(type=MessageEntity.MENTION, offset=0, length=8)])
+    assert mod.find_violation(msg) == "@-упоминание"
+
+
+def test_violation_forward():
+    msg = FakeMessage(text="hello", forward_origin=object())
+    assert mod.find_violation(msg) == "форвард"
+
+
+def test_no_violation_clean_text():
+    assert mod.find_violation(FakeMessage(text="просто привет всем")) is None
+
+
+def test_link_filter_can_be_disabled(monkeypatch):
+    monkeypatch.setattr(config, "NEWCOMER_BLOCK_LINKS", False)
+    msg = FakeMessage(text="http://spam.com", entities=[MessageEntity(type=MessageEntity.URL, offset=0, length=15)])
+    assert mod.find_violation(msg) is None
+
+
+# -- moderate_message ------------------------------------------------------
+
+
+def _link_msg():
+    return FakeMessage(text="http://spam.com", entities=[MessageEntity(type=MessageEntity.URL, offset=0, length=15)])
+
+
+def test_newcomer_link_is_deleted(store, monkeypatch):
+    monkeypatch.setattr(config, "NEWCOMER_ACTION", "delete")
+    msg = _link_msg()
+    update = FakeUpdate(msg, FakeChat(100), FakeUser(42))
+    asyncio.run(mod.moderate_message(update, FakeContext()))
+    assert msg.deleted is True
+    assert store.get_counter(100, "newcomer_filtered") == 1
+
+
+def test_established_user_is_not_filtered(store):
+    # Push the user past the newcomer threshold first.
+    for ts in range(config.NEWCOMER_MAX_MESSAGES):
+        store.touch_member(100, 42, now=1000 + ts)
+    msg = _link_msg()
+    update = FakeUpdate(msg, FakeChat(100), FakeUser(42))
+    asyncio.run(mod.moderate_message(update, FakeContext()))
+    assert msg.deleted is False
+
+
+def test_clean_message_counts_but_is_kept(store):
+    msg = FakeMessage(text="всем привет")
+    update = FakeUpdate(msg, FakeChat(100), FakeUser(42))
+    asyncio.run(mod.moderate_message(update, FakeContext()))
+    assert msg.deleted is False
+    assert store.get_member(100, 42)["message_count"] == 1
+
+
+def test_admin_newcomer_is_not_filtered(store):
+    msg = _link_msg()
+    chat = FakeChat(100, admins=[FakeAdmin(FakeUser(42))])
+    update = FakeUpdate(msg, chat, FakeUser(42))
+    asyncio.run(mod.moderate_message(update, FakeContext()))
+    assert msg.deleted is False
+
+
+def test_edited_message_is_rechecked(store):
+    # User sends one clean message (counts as a newcomer message)...
+    clean = FakeMessage(text="привет")
+    asyncio.run(mod.moderate_message(FakeUpdate(clean, FakeChat(100), FakeUser(42)), FakeContext()))
+    # ...then edits a message into spam: the edit must be caught and not double-counted.
+    spam = _link_msg()
+    asyncio.run(mod.moderate_message(FakeUpdate(spam, FakeChat(100), FakeUser(42), edited=True), FakeContext()))
+    assert spam.deleted is True
+    assert store.get_member(100, 42)["message_count"] == 1
+
+
+def test_action_mute_restricts_and_persists(store, monkeypatch):
+    monkeypatch.setattr(config, "NEWCOMER_ACTION", "mute")
+    msg = _link_msg()
+    chat = FakeChat(100)
+    update = FakeUpdate(msg, chat, FakeUser(42))
+    asyncio.run(mod.moderate_message(update, FakeContext()))
+    assert msg.deleted is True
+    assert chat.restricted == [42]
+    assert store.is_muted(100, 42, now=10**9) is True
+
+
+def test_action_warn_escalates_at_limit(store, monkeypatch):
+    monkeypatch.setattr(config, "NEWCOMER_ACTION", "warn")
+    monkeypatch.setattr(config, "WARN_LIMIT", 1)
+    monkeypatch.setattr(warns, "WARN_ACTION", "mute")
+    msg = _link_msg()
+    chat = FakeChat(100)
+    update = FakeUpdate(msg, chat, FakeUser(42))
+    asyncio.run(mod.moderate_message(update, FakeContext()))
+    assert chat.restricted == [42]  # escalated via warn limit
+    assert store.count_warns(100, 42) == 0  # reset after escalation


### PR DESCRIPTION
## Фаза 1 · 1.1 — Модерация сообщений (ссылки/форварды/edited от новичков)

Первый реальный контентный антиспам: до сих пор фильтрации сообщений не было вовсе (только CAS на входе). Опирается на `core.storage` (#84).

### Что делает
- Фильтрует сообщения **новичков** — пользователь считается новичком, пока не наберёт `max_messages` сообщений **или** не проживёт `max_age_seconds` (что раньше). «Новизна» и счётчик сообщений хранятся в `members`.
- Ловит: **ссылки**, **форварды**, **@-упоминания** (включая `text_mention`), **telegram-инвайты** (`t.me/+`, `joinchat`).
- **Правки (`edited_message`)** повторно прогоняются через фильтр — контент-фильтры PTB матчат и edited, так что «чистый текст → правка в спам» закрывается тем же обработчиком; правки не удваивают счётчик сообщений.

### Действие настраивается
`moderation.newcomer_filter.action`:
- `delete` — удалить сообщение (по умолчанию, удовлетворяет критерию issue);
- `mute` — удалить + замьютить (мьют пишется в `storage` для переживания рестарта);
- `warn` — удалить + варн, при достижении `warn_limit` — эскалация через `_auto_punish` из системы варнов (#83).

### Прочее
- Админов фильтр **не трогает** — проверка `get_administrators` только в момент срабатывания (редко), чтобы не дёргать API на каждое сообщение.
- Каждое срабатывание учитывается счётчиком `newcomer_filtered` (статистика).
- Отдельные фильтры включаются/выключаются (`block_links`/`block_forwards`/`block_mentions`).
- Storage зовётся через `asyncio.to_thread`.

### Тесты
+13 тестов: `find_violation` (ссылка/инвайт/упоминание/форвард/чистый текст/выключение фильтра) и `moderate_message` (удаление у новичка, пропуск established-юзера и админа, подсчёт чистых сообщений, **повторная проверка правки**, действия mute и warn с эскалацией). Локально: `58 passed`, format + lint чистые.

Closes #78