### PR TITLE
feat: 1.4 Флуд-контроль (временный мьют)

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -11,6 +11,7 @@ from core.allowlist import resolve_allowlist, restricted_to_allowed_chats
 from core.config import SENTRY_DSN, TELEGRAM_BOT_TOKEN
 from core.storage import get_storage
 from handlers.admin_handlers import ban_user, mute_user, unban_user, unmute_user
+from handlers.flood_control import flood_control
 from handlers.info_handlers import help_command, start
 from handlers.message_moderation import moderate_message
 from handlers.service_handlers import delete_bad_message, errors_logging, ping
@@ -76,6 +77,13 @@ def main() -> None:
     application.add_handler(MessageHandler(filters.StatusUpdate.LEFT_CHAT_MEMBER, restricted_to_allowed_chats(delete_bad_message)))
     # Delete new chat member
     application.add_handler(MessageHandler(filters.StatusUpdate.NEW_CHAT_MEMBERS, restricted_to_allowed_chats(delete_bad_message)))
+
+    # Flood control runs in its own group so it counts every message regardless
+    # of which group-0 handler also processes it.
+    application.add_handler(
+        MessageHandler(filters.ALL & ~filters.StatusUpdate.ALL, restricted_to_allowed_chats(flood_control)),
+        group=1,
+    )
 
     application.add_error_handler(errors_logging)
 

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -21,6 +21,13 @@ moderation:
     block_links: true
     block_forwards: true
     block_mentions: true
+  # Flood control: more than `limit` messages within `window_seconds` from one
+  # user triggers a temporary mute for `mute_seconds` (native Telegram until_date).
+  flood:
+    enabled: true
+    limit: 7
+    window_seconds: 10
+    mute_seconds: 60
 
 storage:
   # SQLite database file for moderation state. Overridden by the DB_PATH env var.

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -56,6 +56,13 @@ NEWCOMER_BLOCK_LINKS: bool = bool(_newcomer.get("block_links", True))
 NEWCOMER_BLOCK_FORWARDS: bool = bool(_newcomer.get("block_forwards", True))
 NEWCOMER_BLOCK_MENTIONS: bool = bool(_newcomer.get("block_mentions", True))
 
+# Flood control: >limit messages within window_seconds -> temporary mute.
+_flood: dict = cfg.get("moderation", {}).get("flood", {}) or {}
+FLOOD_ENABLED: bool = bool(_flood.get("enabled", True))
+FLOOD_LIMIT: int = int(_flood.get("limit", 7))
+FLOOD_WINDOW: int = int(_flood.get("window_seconds", 10))
+FLOOD_MUTE_SECONDS: int = int(_flood.get("mute_seconds", 60))
+
 # Path to the SQLite database that holds moderation state (warns, mutes, stats).
 # Env DB_PATH wins over config.yaml so deployments can point it at a mounted
 # volume without touching the image.

--- a/src/handlers/flood_control.py
+++ b/src/handlers/flood_control.py
@@ -1,0 +1,83 @@
+"""Flood control: temporarily mute users who send too many messages too fast.
+
+The per-user message timestamps live in memory only — flood is a real-time
+signal and does not need to survive a restart. The mute itself uses Telegram's
+native ``until_date`` so it lifts automatically without any timer of our own;
+it is also recorded in storage for visibility.
+"""
+
+import asyncio
+import time
+from collections import defaultdict, deque
+
+from telegram import Update
+from telegram.error import BadRequest, Forbidden
+from telegram.ext import ContextTypes
+
+from core import config
+from core.config import logger
+from core.storage import get_storage
+
+from .admin_handlers import MUTE_PERMISSIONS
+
+
+class FloodTracker:
+    """Sliding-window message counter per (chat, user)."""
+
+    def __init__(self, limit: int, window: int):
+        self.limit = limit
+        self.window = window
+        self._events: dict = defaultdict(deque)
+
+    def record(self, key, now: float) -> bool:
+        """Record a message; return True if the user is now over the limit."""
+        events = self._events[key]
+        events.append(now)
+        threshold = now - self.window
+        while events and events[0] <= threshold:
+            events.popleft()
+        return len(events) > self.limit
+
+    def reset(self, key) -> None:
+        self._events.pop(key, None)
+
+
+_tracker = FloodTracker(config.FLOOD_LIMIT, config.FLOOD_WINDOW)
+
+
+async def flood_control(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Mute a user who exceeds the message rate within the configured window."""
+    if not config.FLOOD_ENABLED:
+        return
+
+    message = update.effective_message
+    chat = update.effective_chat
+    user = update.effective_user
+    if message is None or chat is None or user is None or user.is_bot:
+        return
+
+    key = (chat.id, user.id)
+    if not _tracker.record(key, time.monotonic()):
+        return
+
+    # Over the limit — but never mute an admin (checked only now, so rarely).
+    admins = await chat.get_administrators()
+    if user.id in {admin.user.id for admin in admins}:
+        _tracker.reset(key)
+        return
+
+    until_ts = int(time.time()) + config.FLOOD_MUTE_SECONDS
+    try:
+        await chat.restrict_member(user_id=user.id, permissions=MUTE_PERMISSIONS, until_date=until_ts)
+    except (BadRequest, Forbidden) as exc:
+        logger.warning("[WARN] Could not mute flooding user %s: %s", user.id, exc)
+        _tracker.reset(key)
+        return
+
+    storage = get_storage()
+    await asyncio.to_thread(storage.add_mute, chat.id, user.id, until_ts)
+    await asyncio.to_thread(storage.increment_counter, chat.id, "flood_muted")
+    _tracker.reset(key)
+
+    logger.info("[INFO] User %s muted for %ss for flooding", user.id, config.FLOOD_MUTE_SECONDS)
+    await message.reply_html(f"⏳ {user.mention_html()} замьючен на {config.FLOOD_MUTE_SECONDS} сек за флуд.")

--- a/tests/test_flood_control.py
+++ b/tests/test_flood_control.py
@@ -1,0 +1,155 @@
+import asyncio
+
+import pytest
+
+import handlers.flood_control as flood
+from core import config
+from core.storage import Storage
+
+# -- FloodTracker (pure) ---------------------------------------------------
+
+
+def test_tracker_under_limit():
+    t = flood.FloodTracker(limit=3, window=10)
+    assert t.record("k", now=1.0) is False
+    assert t.record("k", now=1.1) is False
+    assert t.record("k", now=1.2) is False  # 3 == limit, not over
+
+
+def test_tracker_over_limit():
+    t = flood.FloodTracker(limit=3, window=10)
+    for i in range(3):
+        t.record("k", now=1.0 + i)
+    assert t.record("k", now=1.5) is True  # 4th within window > limit
+
+
+def test_tracker_window_slides():
+    t = flood.FloodTracker(limit=2, window=10)
+    t.record("k", now=0.0)
+    t.record("k", now=1.0)
+    # 20s later the old events have aged out of the window.
+    assert t.record("k", now=21.0) is False
+
+
+def test_tracker_keys_are_independent():
+    t = flood.FloodTracker(limit=1, window=10)
+    t.record("a", now=1.0)
+    assert t.record("b", now=1.0) is False
+
+
+def test_tracker_reset():
+    t = flood.FloodTracker(limit=1, window=10)
+    t.record("k", now=1.0)
+    t.reset("k")
+    assert t.record("k", now=1.1) is False
+
+
+# -- flood_control handler -------------------------------------------------
+
+
+class FakeUser:
+    def __init__(self, user_id, is_bot=False):
+        self.id = user_id
+        self.is_bot = is_bot
+
+    def mention_html(self):
+        return f"user:{self.id}"
+
+
+class FakeAdmin:
+    def __init__(self, user):
+        self.user = user
+
+
+class FakeMessage:
+    def __init__(self):
+        self.replies = []
+
+    async def reply_html(self, text, **kwargs):
+        self.replies.append(text)
+
+
+class FakeChat:
+    def __init__(self, chat_id, admins=()):
+        self.id = chat_id
+        self._admins = list(admins)
+        self.restricted = []  # list of (user_id, until_date)
+
+    async def get_administrators(self):
+        return self._admins
+
+    async def restrict_member(self, user_id, permissions, until_date=None):
+        self.restricted.append((user_id, until_date))
+
+
+class FakeContext:
+    class _Bot:
+        id = 999
+
+    bot = _Bot()
+
+
+class FakeUpdate:
+    def __init__(self, message, chat, user):
+        self.effective_message = message
+        self.effective_chat = chat
+        self.effective_user = user
+
+
+@pytest.fixture
+def store(monkeypatch):
+    s = Storage(":memory:")
+    monkeypatch.setattr(flood, "get_storage", lambda: s)
+    yield s
+    s.close()
+
+
+@pytest.fixture(autouse=True)
+def small_tracker(monkeypatch):
+    monkeypatch.setattr(flood, "_tracker", flood.FloodTracker(limit=2, window=100))
+    monkeypatch.setattr(config, "FLOOD_MUTE_SECONDS", 60)
+
+
+def _send(chat, user_id=42):
+    msg = FakeMessage()
+    update = FakeUpdate(msg, chat, FakeUser(user_id))
+    asyncio.run(flood.flood_control(update, FakeContext()))
+    return msg
+
+
+def test_flood_triggers_temporary_mute(store):
+    chat = FakeChat(100)
+    _send(chat)
+    _send(chat)
+    msg = _send(chat)  # 3rd > limit 2 -> mute
+    assert len(chat.restricted) == 1
+    user_id, until = chat.restricted[0]
+    assert user_id == 42
+    assert until is not None and until > 0  # temporary mute with until_date
+    assert store.is_muted(100, 42, now=0) is True
+    assert store.get_counter(100, "flood_muted") == 1
+    assert any("флуд" in r for r in msg.replies)
+
+
+def test_no_mute_under_limit(store):
+    chat = FakeChat(100)
+    _send(chat)
+    _send(chat)
+    assert chat.restricted == []
+
+
+def test_admin_is_not_muted(store):
+    chat = FakeChat(100, admins=[FakeAdmin(FakeUser(42))])
+    _send(chat)
+    _send(chat)
+    _send(chat)
+    assert chat.restricted == []
+
+
+def test_bot_messages_ignored(store):
+    chat = FakeChat(100)
+    for _ in range(5):
+        msg = FakeMessage()
+        update = FakeUpdate(msg, chat, FakeUser(42, is_bot=True))
+        asyncio.run(flood.flood_control(update, FakeContext()))
+    assert chat.restricted == []


### PR DESCRIPTION
## Фаза 1 · 1.4 — Флуд-контроль

Серия сообщений от одного юзера за короткое окно → временный мьют + предупреждение.

### Что делает
- **Скользящее окно** на юзера (`FloodTracker`, in-memory, `time.monotonic`): >`limit` сообщений за `window_seconds` → срабатывание. Флуд — real-time сигнал, переживать рестарт ему не нужно, поэтому без БД.
- **Временный мьют** на `mute_seconds` через нативный `until_date` в `restrict_member` — Telegram снимает мьют сам, без собственных таймеров. Это закрывает зависимость от #82 (полноценный `/mute 30m` придёт там).
- Мьют дополнительно пишется в `storage` (видимость/restart), срабатывания считаются counter'ом `flood_muted`.
- Предупреждение в чат: «⏳ @user замьючен на N сек за флуд».

### Пороги (config.yaml `moderation.flood`)
`enabled`, `limit` (7), `window_seconds` (10), `mute_seconds` (60).

### Интеграция
- Обработчик в **отдельной группе** (`group=1`), чтобы считать каждое сообщение независимо от обработчиков группы 0 (newcomer-фильтр, media-delete).
- Админов не мьютит — `get_administrators` дёргается только в момент срабатывания (редко).
- Ботов игнорирует.

### Тесты
+9 тестов: `FloodTracker` (под/над лимитом, сдвиг окна, независимость ключей, reset) и обработчик (срабатывание мьюта с `until_date` + персист + counter + warning, отсутствие мьюта под лимитом, защита админа, игнор ботов). Локально: `67 passed`, format + lint чистые.

Closes #81