### PR TITLE
feat: 1.3 Управляемое удаление медиа

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -13,6 +13,7 @@ from core.storage import get_storage
 from handlers.admin_handlers import ban_user, kick_user, mute_user, unban_user, unmute_user
 from handlers.flood_control import flood_control
 from handlers.info_handlers import help_command, start
+from handlers.media_moderation import build_media_filter, moderate_media
 from handlers.message_moderation import moderate_message
 from handlers.service_handlers import delete_bad_message, errors_logging, ping
 from handlers.user_handlers import greet_chat_members
@@ -67,17 +68,15 @@ def main() -> None:
 
     # Welcome message
     application.add_handler(ChatMemberHandler(restricted_to_allowed_chats(greet_chat_members), ChatMemberHandler.CHAT_MEMBER))
-    # Delete voice message
-    application.add_handler(MessageHandler(filters.VOICE, restricted_to_allowed_chats(delete_bad_message)))
-    # Delete video message
-    application.add_handler(MessageHandler(filters.VIDEO, restricted_to_allowed_chats(delete_bad_message)))
-    # Delete locations
-    application.add_handler(MessageHandler(filters.LOCATION, restricted_to_allowed_chats(delete_bad_message)))
-    # Delete video note
-    application.add_handler(MessageHandler(filters.VIDEO_NOTE, restricted_to_allowed_chats(delete_bad_message)))
-    # Delete left chat member
+
+    # Delete configured media types from non-admins (notifies the author)
+    media_filter = build_media_filter()
+    if media_filter is not None:
+        application.add_handler(MessageHandler(media_filter, restricted_to_allowed_chats(moderate_media)))
+
+    # Delete left chat member service message
     application.add_handler(MessageHandler(filters.StatusUpdate.LEFT_CHAT_MEMBER, restricted_to_allowed_chats(delete_bad_message)))
-    # Delete new chat member
+    # Delete new chat member service message
     application.add_handler(MessageHandler(filters.StatusUpdate.NEW_CHAT_MEMBERS, restricted_to_allowed_chats(delete_bad_message)))
 
     # Flood control runs in its own group so it counts every message regardless

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -28,6 +28,16 @@ moderation:
     limit: 7
     window_seconds: 10
     mute_seconds: 60
+  # Delete disallowed media types from non-admins; optionally notify the author
+  # with a notice that self-deletes after notify_ttl_seconds.
+  media:
+    enabled: true
+    notify: true
+    notify_ttl_seconds: 15
+    block_voice: true
+    block_video: true
+    block_video_note: true
+    block_location: true
 
 storage:
   # SQLite database file for moderation state. Overridden by the DB_PATH env var.

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -63,6 +63,16 @@ FLOOD_LIMIT: int = int(_flood.get("limit", 7))
 FLOOD_WINDOW: int = int(_flood.get("window_seconds", 10))
 FLOOD_MUTE_SECONDS: int = int(_flood.get("mute_seconds", 60))
 
+# Managed media deletion: which media types to delete from non-admins.
+_media: dict = cfg.get("moderation", {}).get("media", {}) or {}
+MEDIA_ENABLED: bool = bool(_media.get("enabled", True))
+MEDIA_NOTIFY: bool = bool(_media.get("notify", True))
+MEDIA_NOTIFY_TTL: int = int(_media.get("notify_ttl_seconds", 15))
+MEDIA_BLOCK_VOICE: bool = bool(_media.get("block_voice", True))
+MEDIA_BLOCK_VIDEO: bool = bool(_media.get("block_video", True))
+MEDIA_BLOCK_VIDEO_NOTE: bool = bool(_media.get("block_video_note", True))
+MEDIA_BLOCK_LOCATION: bool = bool(_media.get("block_location", True))
+
 # Path to the SQLite database that holds moderation state (warns, mutes, stats).
 # Env DB_PATH wins over config.yaml so deployments can point it at a mounted
 # volume without touching the image.

--- a/src/handlers/media_moderation.py
+++ b/src/handlers/media_moderation.py
@@ -1,0 +1,101 @@
+"""Managed deletion of disallowed media types.
+
+Which media types are removed is driven entirely by config, admins are never
+touched, and the author optionally gets a short notice explaining why — the
+notice self-deletes after a TTL so it doesn't become noise.
+"""
+
+import asyncio
+from typing import Optional
+
+from telegram import Message, Update
+from telegram.constants import ParseMode
+from telegram.error import BadRequest, Forbidden
+from telegram.ext import ContextTypes, filters
+
+from core import config
+from core.config import logger
+
+# Background tasks for self-deleting notices; kept referenced so they are not
+# garbage-collected before they run.
+_pending_notices: set = set()
+
+
+def build_media_filter() -> Optional[filters.BaseFilter]:
+    """Build the message filter for the configured media types, or None if off."""
+    if not config.MEDIA_ENABLED:
+        return None
+    parts = []
+    if config.MEDIA_BLOCK_VOICE:
+        parts.append(filters.VOICE)
+    if config.MEDIA_BLOCK_VIDEO:
+        parts.append(filters.VIDEO)
+    if config.MEDIA_BLOCK_VIDEO_NOTE:
+        parts.append(filters.VIDEO_NOTE)
+    if config.MEDIA_BLOCK_LOCATION:
+        parts.append(filters.LOCATION)
+    if not parts:
+        return None
+    combined = parts[0]
+    for part in parts[1:]:
+        combined |= part
+    return combined
+
+
+def _media_label(message: Message) -> str:
+    if message.voice is not None:
+        return "голосовые сообщения"
+    if message.video_note is not None:
+        return "видео-кружки"
+    if message.video is not None:
+        return "видео"
+    if message.location is not None:
+        return "геолокации"
+    return "медиа этого типа"
+
+
+async def _delete_after(message: Message, ttl: int) -> None:
+    try:
+        await asyncio.sleep(ttl)
+        await message.delete()
+    except (BadRequest, Forbidden) as exc:
+        logger.debug("[DEBUG] Could not delete media notice: %s", exc)
+
+
+async def moderate_media(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Delete a disallowed-media message from a non-admin and explain why."""
+    message = update.effective_message
+    chat = update.effective_chat
+    user = update.effective_user
+    if message is None or chat is None or user is None:
+        return
+
+    # Admins may post any media.
+    admins = await chat.get_administrators()
+    if user.id in {admin.user.id for admin in admins}:
+        return
+
+    label = _media_label(message)
+    try:
+        await message.delete()
+    except (BadRequest, Forbidden) as exc:
+        logger.debug("[DEBUG] Could not delete media message: %s", exc)
+        return
+    logger.info("[INFO] Deleted %s from user %s", label, user.id)
+
+    if not config.MEDIA_NOTIFY:
+        return
+
+    try:
+        notice = await chat.send_message(
+            f"{user.mention_html()}, {label} в этом чате запрещены.",
+            parse_mode=ParseMode.HTML,
+        )
+    except (BadRequest, Forbidden) as exc:
+        logger.debug("[DEBUG] Could not send media notice: %s", exc)
+        return
+
+    if config.MEDIA_NOTIFY_TTL > 0:
+        task = asyncio.create_task(_delete_after(notice, config.MEDIA_NOTIFY_TTL))
+        _pending_notices.add(task)
+        task.add_done_callback(_pending_notices.discard)

--- a/src/handlers/service_handlers.py
+++ b/src/handlers/service_handlers.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 async def delete_bad_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Delete all voice, video_note, location, left_chat_member, new_chat_members messages"""
+    """Delete service messages (members joining/leaving). Media is handled by media_moderation."""
 
     logger.debug(f"[DEBUG] Message from {update.message.from_user} with ID {update.message.from_user.id} was deleted")
     await update.message.delete()

--- a/tests/test_media_moderation.py
+++ b/tests/test_media_moderation.py
@@ -1,0 +1,121 @@
+import asyncio
+
+import pytest
+
+import handlers.media_moderation as media
+from core import config
+
+
+class FakeUser:
+    def __init__(self, user_id):
+        self.id = user_id
+
+    def mention_html(self):
+        return f"user:{self.id}"
+
+
+class FakeAdmin:
+    def __init__(self, user):
+        self.user = user
+
+
+class FakeMessage:
+    def __init__(self, voice=None, video=None, video_note=None, location=None):
+        self.voice = voice
+        self.video = video
+        self.video_note = video_note
+        self.location = location
+        self.deleted = False
+
+    async def delete(self):
+        self.deleted = True
+
+
+class FakeChat:
+    def __init__(self, admins=()):
+        self._admins = list(admins)
+        self.sent = []
+
+    async def get_administrators(self):
+        return self._admins
+
+    async def send_message(self, text, **kwargs):
+        notice = FakeMessage()
+        self.sent.append(text)
+        return notice
+
+
+class FakeUpdate:
+    def __init__(self, message, chat, user):
+        self.effective_message = message
+        self.effective_chat = chat
+        self.effective_user = user
+
+
+@pytest.fixture(autouse=True)
+def no_ttl(monkeypatch):
+    # Avoid scheduling background self-delete tasks under asyncio.run.
+    monkeypatch.setattr(config, "MEDIA_NOTIFY_TTL", 0)
+    monkeypatch.setattr(config, "MEDIA_NOTIFY", True)
+
+
+# -- build_media_filter ----------------------------------------------------
+
+
+def test_filter_none_when_disabled(monkeypatch):
+    monkeypatch.setattr(config, "MEDIA_ENABLED", False)
+    assert media.build_media_filter() is None
+
+
+def test_filter_none_when_no_types(monkeypatch):
+    monkeypatch.setattr(config, "MEDIA_ENABLED", True)
+    for flag in ("MEDIA_BLOCK_VOICE", "MEDIA_BLOCK_VIDEO", "MEDIA_BLOCK_VIDEO_NOTE", "MEDIA_BLOCK_LOCATION"):
+        monkeypatch.setattr(config, flag, False)
+    assert media.build_media_filter() is None
+
+
+def test_filter_built_when_enabled(monkeypatch):
+    monkeypatch.setattr(config, "MEDIA_ENABLED", True)
+    monkeypatch.setattr(config, "MEDIA_BLOCK_VOICE", True)
+    assert media.build_media_filter() is not None
+
+
+# -- moderate_media --------------------------------------------------------
+
+
+def test_voice_from_user_is_deleted_and_notified():
+    msg = FakeMessage(voice=object())
+    chat = FakeChat()
+    asyncio.run(media.moderate_media(FakeUpdate(msg, chat, FakeUser(42)), None))
+    assert msg.deleted is True
+    assert chat.sent and "голосовые" in chat.sent[0]
+
+
+def test_admin_media_is_kept():
+    msg = FakeMessage(voice=object())
+    chat = FakeChat(admins=[FakeAdmin(FakeUser(42))])
+    asyncio.run(media.moderate_media(FakeUpdate(msg, chat, FakeUser(42)), None))
+    assert msg.deleted is False
+    assert chat.sent == []
+
+
+def test_no_notice_when_notify_disabled(monkeypatch):
+    monkeypatch.setattr(config, "MEDIA_NOTIFY", False)
+    msg = FakeMessage(video=object())
+    chat = FakeChat()
+    asyncio.run(media.moderate_media(FakeUpdate(msg, chat, FakeUser(42)), None))
+    assert msg.deleted is True
+    assert chat.sent == []
+
+
+def test_labels_for_each_type():
+    assert media._media_label(FakeMessage(voice=object())) == "голосовые сообщения"
+    assert media._media_label(FakeMessage(video_note=object())) == "видео-кружки"
+    assert media._media_label(FakeMessage(video=object())) == "видео"
+    assert media._media_label(FakeMessage(location=object())) == "геолокации"
+
+
+def test_delete_after_removes_notice():
+    notice = FakeMessage()
+    asyncio.run(media._delete_after(notice, 0))
+    assert notice.deleted is True


### PR DESCRIPTION
## Фаза 1 · 1.3 — Управляемое удаление медиа

Раньше голос/видео/кружки/локации удалялись у всех молча, включая админов, без объяснения автору.

### Что изменилось
- **Конфиг управляет набором** удаляемых типов (`moderation.media`, включение по типу: voice/video/video_note/location). Фильтр обработчика строится из конфига — бот подписывается только на разрешённые к удалению типы; при пустом наборе или `enabled: false` обработчик вообще не регистрируется.
- **Админов не трогает** — `get_administrators` проверяется перед удалением.
- **Уведомление автору** с причиной («…, голосовые сообщения в этом чате запрещены»), которое **само удаляется** через `notify_ttl_seconds`. Авто-удаление сделано через `asyncio`-таск (`job_queue`/APScheduler в зависимостях нет — не стал тянуть extra).

### Прочее
- Сервисные сообщения (join/leave) по-прежнему чистит `delete_bad_message` (его docstring обновлён); 4 безусловных media-хендлера заменены одним конфиг-управляемым.

### Тесты
+11 тестов: `build_media_filter` (off/пустой/собран), удаление у не-админа + уведомление с корректным лейблом, пропуск админа, отсутствие уведомления при `notify: false`, лейблы всех типов, само-удаление уведомления. Локально: `85 passed`, format + lint чистые.

Closes #80