### PR TITLE
feat: 1.2 Капча/верификация новых участников

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -5,12 +5,13 @@ import logging
 
 import sentry_sdk
 from telegram import Update
-from telegram.ext import Application, ChatMemberHandler, CommandHandler, MessageHandler, filters
+from telegram.ext import Application, CallbackQueryHandler, ChatMemberHandler, CommandHandler, MessageHandler, filters
 
 from core.allowlist import resolve_allowlist, restricted_to_allowed_chats
 from core.config import SENTRY_DSN, TELEGRAM_BOT_TOKEN
 from core.storage import get_storage
 from handlers.admin_handlers import ban_user, kick_user, mute_user, unban_user, unmute_user
+from handlers.captcha import captcha_callback
 from handlers.flood_control import flood_control
 from handlers.info_handlers import help_command, start
 from handlers.media_moderation import build_media_filter, moderate_media
@@ -67,8 +68,10 @@ def main() -> None:
         )
     )
 
-    # Welcome message
+    # Welcome message / captcha challenge on join
     application.add_handler(ChatMemberHandler(restricted_to_allowed_chats(greet_chat_members), ChatMemberHandler.CHAT_MEMBER))
+    # Captcha button taps
+    application.add_handler(CallbackQueryHandler(restricted_to_allowed_chats(captcha_callback), pattern=r"^captcha:"))
 
     # Delete configured media types from non-admins (notifies the author)
     media_filter = build_media_filter()

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -28,6 +28,12 @@ moderation:
     limit: 7
     window_seconds: 10
     mute_seconds: 60
+  # Captcha for new members: mute on join until they tap a button. Pass within
+  # timeout_seconds -> unmute + welcome; otherwise fail_action (kick|ban).
+  captcha:
+    enabled: true
+    timeout_seconds: 60
+    fail_action: kick
   # Delete disallowed media types from non-admins; optionally notify the author
   # with a notice that self-deletes after notify_ttl_seconds.
   media:

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -63,6 +63,13 @@ FLOOD_LIMIT: int = int(_flood.get("limit", 7))
 FLOOD_WINDOW: int = int(_flood.get("window_seconds", 10))
 FLOOD_MUTE_SECONDS: int = int(_flood.get("mute_seconds", 60))
 
+# Captcha / verification of new members.
+_captcha: dict = cfg.get("moderation", {}).get("captcha", {}) or {}
+CAPTCHA_ENABLED: bool = bool(_captcha.get("enabled", True))
+CAPTCHA_TIMEOUT: int = int(_captcha.get("timeout_seconds", 60))
+_captcha_fail: str = str(_captcha.get("fail_action", "kick")).lower()
+CAPTCHA_FAIL_ACTION: str = _captcha_fail if _captcha_fail in {"kick", "ban"} else "kick"
+
 # Managed media deletion: which media types to delete from non-admins.
 _media: dict = cfg.get("moderation", {}).get("media", {}) or {}
 MEDIA_ENABLED: bool = bool(_media.get("enabled", True))

--- a/src/handlers/captcha.py
+++ b/src/handlers/captcha.py
@@ -1,0 +1,134 @@
+"""Button captcha for new chat members.
+
+On join a newcomer is muted and shown a button. Tapping it within the timeout
+unmutes them and posts the welcome; otherwise they are kicked or banned. A CAS
+hit never reaches here — those are banned outright before the challenge.
+
+Pending challenges live in memory and the timeout is an asyncio task (no
+job-queue dependency). The mute is permanent until the user passes — never
+fail-open, or an automated bot would gain write access just by waiting.
+"""
+
+import asyncio
+from typing import Optional
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, LinkPreviewOptions, Update, User
+from telegram.constants import ParseMode
+from telegram.error import BadRequest, Forbidden
+from telegram.ext import ContextTypes
+
+from core import config
+from core.config import CHAT_RULES_URL, logger
+from core.storage import get_storage
+
+from .admin_handlers import MUTE_PERMISSIONS, UNMUTE_PERMISSIONS
+
+# (chat_id, user_id) -> challenge Message, so it can be removed on pass/timeout.
+_pending: dict = {}
+# Strong refs to in-flight timeout tasks so they are not garbage-collected.
+_tasks: set = set()
+
+
+def _key(chat_id: int, user_id: int) -> tuple:
+    return (chat_id, user_id)
+
+
+async def start_challenge(chat, user: User) -> None:
+    """Mute the newcomer and post the captcha button."""
+    try:
+        await chat.restrict_member(user_id=user.id, permissions=MUTE_PERMISSIONS)
+    except (BadRequest, Forbidden) as exc:
+        logger.warning("[WARN] Could not mute newcomer %s for captcha: %s", user.id, exc)
+        return
+
+    await asyncio.to_thread(get_storage().add_mute, chat.id, user.id, None)
+
+    keyboard = InlineKeyboardMarkup([[InlineKeyboardButton("Я не бот ✅", callback_data=f"captcha:{user.id}")]])
+    try:
+        message = await chat.send_message(
+            f"{user.mention_html()}, подтверди, что ты не бот — нажми кнопку в течение {config.CAPTCHA_TIMEOUT} сек.",
+            parse_mode=ParseMode.HTML,
+            reply_markup=keyboard,
+        )
+    except (BadRequest, Forbidden) as exc:
+        logger.warning("[WARN] Could not send captcha to %s: %s", user.id, exc)
+        return
+
+    _pending[_key(chat.id, user.id)] = message
+    task = asyncio.create_task(_expire(chat, user.id))
+    _tasks.add(task)
+    task.add_done_callback(_tasks.discard)
+    logger.info("[INFO] Captcha started for user %s", user.id)
+
+
+async def _expire(chat, user_id: int) -> None:
+    """After the timeout, punish the user if they still haven't passed."""
+    await asyncio.sleep(config.CAPTCHA_TIMEOUT)
+    message = _pending.pop(_key(chat.id, user_id), None)
+    if message is None:
+        return  # already passed
+
+    try:
+        await message.delete()
+    except BadRequest, Forbidden:
+        pass
+
+    try:
+        await chat.ban_member(user_id=user_id)
+        if config.CAPTCHA_FAIL_ACTION == "kick":
+            # Kick = ban + unban, so the user may rejoin and try again.
+            await chat.unban_member(user_id=user_id)
+    except (BadRequest, Forbidden) as exc:
+        logger.warning("[WARN] Captcha fail-action for %s failed: %s", user_id, exc)
+    logger.info("[INFO] Captcha timed out for user %s (action=%s)", user_id, config.CAPTCHA_FAIL_ACTION)
+
+
+async def captcha_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle the button tap: only the challenged user can pass."""
+    query = update.callback_query
+    chat = update.effective_chat
+    if query is None or chat is None:
+        return
+
+    target_id = _parse_target(query.data)
+    if target_id is None:
+        await query.answer()
+        return
+
+    if query.from_user.id != target_id:
+        await query.answer("Эта кнопка не для тебя 🙂")
+        return
+
+    message = _pending.pop(_key(chat.id, target_id), None)
+
+    try:
+        await chat.restrict_member(user_id=target_id, permissions=UNMUTE_PERMISSIONS)
+    except (BadRequest, Forbidden) as exc:
+        logger.warning("[WARN] Could not unmute %s after captcha: %s", target_id, exc)
+    await asyncio.to_thread(get_storage().remove_mute, chat.id, target_id)
+
+    await query.answer("Спасибо! Доступ открыт.")
+    if message is not None:
+        try:
+            await message.delete()
+        except BadRequest, Forbidden:
+            pass
+
+    try:
+        await chat.send_message(
+            f'Хомячок {query.from_user.mention_html()} прошёл проверку.\n\nВелкам и прочти <a href="{CHAT_RULES_URL}">правила</a>!',
+            parse_mode=ParseMode.HTML,
+            link_preview_options=LinkPreviewOptions(is_disabled=True),
+        )
+    except (BadRequest, Forbidden) as exc:
+        logger.debug("[DEBUG] Could not send welcome after captcha: %s", exc)
+    logger.info("[INFO] User %s passed captcha", target_id)
+
+
+def _parse_target(data: Optional[str]) -> Optional[int]:
+    if not data or ":" not in data:
+        return None
+    try:
+        return int(data.split(":", 1)[1])
+    except ValueError:
+        return None

--- a/src/handlers/user_handlers.py
+++ b/src/handlers/user_handlers.py
@@ -5,10 +5,12 @@ from telegram import LinkPreviewOptions, Update
 from telegram.constants import ParseMode
 from telegram.ext import ContextTypes
 
+from core import config
 from core.cas import casapi
 from core.config import CHAT_RULES_URL
 from core.storage import get_storage
 
+from .captcha import start_challenge
 from .helpers import extract_status_change
 
 logger = logging.getLogger(__name__)
@@ -33,8 +35,12 @@ async def greet_chat_members(update: Update, context: ContextTypes.DEFAULT_TYPE)
         # CAS returns ok=True when the user is listed as a spammer,
         # and ok=False ("Record not found.") when the user is clean.
         if check["ok"]:
+            # CAS hit -> ban outright, skipping the captcha.
             logger.info(f"[INFO] User with ID {user_id} found in CAS, was banned")
             await update.effective_chat.ban_member(user_id=user_id)
+        elif config.CAPTCHA_ENABLED:
+            # Make the newcomer pass the captcha before they can write or be greeted.
+            await start_challenge(update.effective_chat, new_user)
         else:
             await update.effective_chat.send_message(
                 f'Хомячок {member_name} пришёл.\n\nВелкам и прочти <a href="{CHAT_RULES_URL}">правила</a>!',

--- a/tests/test_captcha.py
+++ b/tests/test_captcha.py
@@ -1,0 +1,155 @@
+import asyncio
+
+import pytest
+
+import handlers.captcha as captcha
+from core import config
+from core.storage import Storage
+
+
+class _DummyTask:
+    def add_done_callback(self, cb):
+        pass
+
+
+class FakeUser:
+    def __init__(self, user_id):
+        self.id = user_id
+
+    def mention_html(self):
+        return f"user:{self.id}"
+
+
+class FakeMessage:
+    def __init__(self):
+        self.deleted = False
+
+    async def delete(self):
+        self.deleted = True
+
+
+class FakeChat:
+    def __init__(self, chat_id=100):
+        self.id = chat_id
+        self.restricted = []  # (user_id, permissions)
+        self.banned = []
+        self.unbanned = []
+        self.sent = []
+
+    async def restrict_member(self, user_id, permissions):
+        self.restricted.append((user_id, permissions))
+
+    async def ban_member(self, user_id):
+        self.banned.append(user_id)
+
+    async def unban_member(self, user_id):
+        self.unbanned.append(user_id)
+
+    async def send_message(self, text, **kwargs):
+        msg = FakeMessage()
+        self.sent.append(text)
+        return msg
+
+
+class FakeQuery:
+    def __init__(self, data, from_user):
+        self.data = data
+        self.from_user = from_user
+        self.answers = []
+
+    async def answer(self, text=None, **kwargs):
+        self.answers.append(text)
+
+
+class FakeUpdate:
+    def __init__(self, chat, query):
+        self.effective_chat = chat
+        self.callback_query = query
+
+
+@pytest.fixture
+def store(monkeypatch):
+    s = Storage(":memory:")
+    monkeypatch.setattr(captcha, "get_storage", lambda: s)
+    yield s
+    s.close()
+
+
+@pytest.fixture(autouse=True)
+def clear_pending():
+    captcha._pending.clear()
+    yield
+    captcha._pending.clear()
+
+
+@pytest.fixture
+def no_scheduling(monkeypatch):
+    # Don't actually schedule the expiry task during start_challenge tests.
+    def _fake_create_task(coro):
+        coro.close()
+        return _DummyTask()
+
+    monkeypatch.setattr(captcha.asyncio, "create_task", _fake_create_task)
+
+
+def test_start_challenge_mutes_and_prompts(store, no_scheduling):
+    chat = FakeChat()
+    asyncio.run(captcha.start_challenge(chat, FakeUser(42)))
+    assert chat.restricted and chat.restricted[0] == (42, captcha.MUTE_PERMISSIONS)
+    assert chat.sent  # captcha prompt posted
+    assert captcha._key(100, 42) in captcha._pending
+    assert store.is_muted(100, 42, now=10**9) is True
+
+
+def test_pass_unmutes_and_welcomes(store):
+    chat = FakeChat()
+    store.add_mute(100, 42, until=None)
+    captcha._pending[captcha._key(100, 42)] = FakeMessage()
+    query = FakeQuery("captcha:42", FakeUser(42))
+    asyncio.run(captcha.captcha_callback(FakeUpdate(chat, query), None))
+
+    assert chat.restricted and chat.restricted[0] == (42, captcha.UNMUTE_PERMISSIONS)
+    assert captcha._key(100, 42) not in captcha._pending
+    assert store.is_muted(100, 42, now=0) is False
+    assert chat.sent  # welcome posted
+    assert query.answers  # popup answered
+
+
+def test_wrong_user_cannot_pass(store):
+    chat = FakeChat()
+    captcha._pending[captcha._key(100, 42)] = FakeMessage()
+    query = FakeQuery("captcha:42", FakeUser(7))  # someone else taps
+    asyncio.run(captcha.captcha_callback(FakeUpdate(chat, query), None))
+
+    assert chat.restricted == []  # not unmuted
+    assert captcha._key(100, 42) in captcha._pending  # still pending
+    assert any("не для тебя" in (a or "") for a in query.answers)
+
+
+def test_expire_kicks_when_unsolved(store, monkeypatch):
+    monkeypatch.setattr(config, "CAPTCHA_TIMEOUT", 0)
+    monkeypatch.setattr(config, "CAPTCHA_FAIL_ACTION", "kick")
+    chat = FakeChat()
+    challenge = FakeMessage()
+    captcha._pending[captcha._key(100, 42)] = challenge
+    asyncio.run(captcha._expire(chat, 42))
+
+    assert chat.banned == [42] and chat.unbanned == [42]  # kick = ban + unban
+    assert challenge.deleted is True
+    assert captcha._key(100, 42) not in captcha._pending
+
+
+def test_expire_bans_when_configured(store, monkeypatch):
+    monkeypatch.setattr(config, "CAPTCHA_TIMEOUT", 0)
+    monkeypatch.setattr(config, "CAPTCHA_FAIL_ACTION", "ban")
+    chat = FakeChat()
+    captcha._pending[captcha._key(100, 42)] = FakeMessage()
+    asyncio.run(captcha._expire(chat, 42))
+    assert chat.banned == [42] and chat.unbanned == []
+
+
+def test_expire_noop_when_already_passed(store, monkeypatch):
+    monkeypatch.setattr(config, "CAPTCHA_TIMEOUT", 0)
+    chat = FakeChat()
+    asyncio.run(captcha._expire(chat, 42))  # nothing pending
+    assert chat.banned == []


### PR DESCRIPTION
## Фаза 1 · 1.2 — Капча/верификация новых участников

Последний issue ROADMAP. CAS пропускает много свежих спамеров — добавлен барьер с кнопкой.

### Поведение
- При входе новичок **мьютится** и получает сообщение с инлайн-кнопкой «Я не бот ✅».
- Нажал в течение `timeout_seconds` → **размьют + приветствие**.
- Не успел → **kick или ban** (`moderation.captcha.fail_action`).
- **CAS-хит банится сразу**, минуя капчу.
- Кнопку может нажать **только сам проверяемый** (чужое нажатие → «Эта кнопка не для тебя»).

### Реализация
- Встроено в `greet_chat_members` (CAS → captcha → welcome).
- Таймаут — `asyncio`-таск (job-queue/APScheduler в зависимостях нет).
- Мьют **перманентный до прохождения** — осознанно не fail-open: иначе автоматический бот получил бы право писать просто переждав таймер (прямо нарушало бы критерий issue). Мьют пишется в `storage`.
- Конфиг: `moderation.captcha` (`enabled` / `timeout_seconds` / `fail_action`).
- `CallbackQueryHandler` с `pattern=^captcha:`, под гардом allowlist.

### Заметка по Python 3.14
В bare-`except` ruff (`target-version = py314`) убирает скобки у кортежа исключений — `except A, B:` в 3.14 легально и эквивалентно `except (A, B):` (ловит оба). Это формат, который требует CI-тулчейн.

### Тесты
+6 тестов: старт челленджа (мьют + промпт + персист), прохождение (размьют + приветствие + очистка), чужое нажатие отклоняется, таймаут kick (ban+unban) и ban, noop если уже прошёл. Локально: `105 passed`, format + lint чистые.

Closes #79