### PR TITLE
feat: audit-log модерации, мягкое удаление варнов и ретеншен истории

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -9,6 +9,7 @@ from telegram.ext import Application, CallbackQueryHandler, ChatMemberHandler, C
 
 from core.allowlist import resolve_allowlist, restricted_to_allowed_chats
 from core.config import SENTRY_DSN, TELEGRAM_BOT_TOKEN
+from core.retention import start_retention
 from core.storage import get_storage
 from handlers.admin_handlers import ban_user, kick_user, mute_user, unban_user, unmute_user
 from handlers.captcha import captcha_callback, rearm_captchas
@@ -26,10 +27,12 @@ logger = logging.getLogger(__name__)
 
 
 async def _post_init(application) -> None:
-    """Runtime setup once the bot is ready: resolve the allowlist and rearm
-    any captcha challenges that were pending when the process last stopped."""
+    """Runtime setup once the bot is ready: resolve the allowlist, rearm any
+    captcha challenges that were pending when the process last stopped, and
+    start the daily retention purge."""
     await resolve_allowlist(application)
     await rearm_captchas(application)
+    start_retention(application)
 
 
 def main() -> None:

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -49,4 +49,10 @@ storage:
   # SQLite database file for moderation state. Overridden by the DB_PATH env var.
   # Point this at a mounted volume so state survives restarts.
   path: 'moder.db'
+  # History retention: audit log, soft-deleted warns and per-day message stats
+  # older than `days` are hard-deleted once a day at `purge_hour_utc`.
+  # Live moderation state (active warns, mutes, members) is never purged.
+  retention:
+    days: 365          # env RETENTION_DAYS wins
+    purge_hour_utc: 4  # env RETENTION_PURGE_HOUR wins
 

--- a/src/core/audit.py
+++ b/src/core/audit.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""Audit log of moderation events.
+
+Every moderation action (manual command, automatic punishment, captcha
+outcome, filter hit, join/leave) is appended to the ``audit_log`` table so the
+history survives for analytics even when the live state changes (e.g. warns
+are cleared after an auto-punishment). Events are recorded only after the
+Telegram action succeeded — failed actions are not audited.
+"""
+
+import asyncio
+import enum
+import logging
+from typing import Optional
+
+from core.storage import get_storage
+
+logger = logging.getLogger(__name__)
+
+
+class AuditEvent(enum.StrEnum):
+    """Event types stored in ``audit_log.event``."""
+
+    BAN = "ban"
+    UNBAN = "unban"
+    KICK = "kick"
+    MUTE = "mute"
+    UNMUTE = "unmute"
+    WARN = "warn"
+    UNWARN = "unwarn"
+    WARNS_CLEARED = "warns_cleared"
+    AUTO_BAN = "auto_ban"
+    AUTO_MUTE = "auto_mute"
+    CAPTCHA_SHOWN = "captcha_shown"
+    CAPTCHA_PASSED = "captcha_passed"
+    CAPTCHA_FAILED = "captcha_failed"
+    CAS_BAN = "cas_ban"
+    FLOOD_MUTE = "flood_mute"
+    NEWCOMER_FILTERED = "newcomer_filtered"
+    MEDIA_DELETED = "media_deleted"
+    MEMBER_JOINED = "member_joined"
+    MEMBER_LEFT = "member_left"
+
+
+async def record_event(
+    chat_id: int,
+    event: AuditEvent,
+    *,
+    user_id: Optional[int] = None,
+    actor_id: Optional[int] = None,
+    reason: Optional[str] = None,
+    meta: Optional[dict] = None,
+) -> None:
+    """Persist an audit event; a storage failure must never break moderation."""
+    try:
+        await asyncio.to_thread(get_storage().add_audit_event, chat_id, str(event), user_id, actor_id, reason, meta)
+    except Exception:
+        logger.exception("[ERROR] Failed to record audit event %s in chat %s", event, chat_id)

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -85,6 +85,13 @@ MEDIA_BLOCK_LOCATION: bool = bool(_media.get("block_location", True))
 # volume without touching the image.
 DB_PATH: str = os.getenv("DB_PATH") or str(cfg.get("storage", {}).get("path", "moder.db"))
 
+# History retention: how many days of audit log / soft-deleted warns / message
+# stats to keep, and at which UTC hour the daily purge runs. Env vars win over
+# config.yaml, same as DB_PATH.
+_retention: dict = cfg.get("storage", {}).get("retention", {}) or {}
+RETENTION_DAYS: int = int(os.getenv("RETENTION_DAYS") or _retention.get("days", 365))
+RETENTION_PURGE_HOUR: int = int(os.getenv("RETENTION_PURGE_HOUR") or _retention.get("purge_hour_utc", 4)) % 24
+
 DEBUG: bool = _parse_bool(os.getenv("DEBUG"))
 SENTRY_DSN: Optional[str] = os.getenv("SENTRY_DSN")
 

--- a/src/core/retention.py
+++ b/src/core/retention.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""Daily retention purge of aged history.
+
+History tables (audit log, soft-deleted warns, per-day message stats) are
+hard-deleted once they are older than the configured retention window. The
+purge runs once right after startup (catching up after downtime) and then
+daily at a fixed UTC hour — a plain asyncio task, same pattern as the captcha
+timers (no job-queue dependency).
+"""
+
+import asyncio
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from core import config
+from core.config import logger
+from core.storage import get_storage
+
+# Strong ref to the loop task so it is not garbage-collected.
+_task: Optional[asyncio.Task] = None
+
+
+def seconds_until(hour_utc: int, now: Optional[int] = None) -> int:
+    """Seconds from ``now`` to the next occurrence of ``hour_utc:00`` UTC."""
+    ts = int(time.time()) if now is None else now
+    current = datetime.fromtimestamp(ts, tz=timezone.utc)
+    target = current.replace(hour=hour_utc, minute=0, second=0, microsecond=0)
+    if target <= current:
+        target += timedelta(days=1)
+    return int((target - current).total_seconds())
+
+
+async def _purge_once() -> None:
+    counts = await asyncio.to_thread(get_storage().purge_old_data, config.RETENTION_DAYS)
+    logger.info("[INFO] Retention purge done (keep %s days): %s", config.RETENTION_DAYS, counts)
+
+
+async def retention_loop() -> None:
+    """Purge on startup, then daily at RETENTION_PURGE_HOUR UTC, forever."""
+    while True:
+        try:
+            await _purge_once()
+        except Exception:
+            # One failed purge must not kill the loop; the next run retries.
+            logger.exception("[ERROR] Retention purge failed")
+        await asyncio.sleep(seconds_until(config.RETENTION_PURGE_HOUR))
+
+
+def start_retention(application) -> None:
+    """Start the retention task once the bot is up (called from post_init)."""
+    global _task
+    _task = asyncio.create_task(retention_loop())

--- a/src/core/storage.py
+++ b/src/core/storage.py
@@ -12,10 +12,12 @@ connection is opened with ``check_same_thread=False`` and guarded by a lock so
 it is safe to use from the thread pool.
 """
 
+import json
 import os
 import sqlite3
 import threading
 import time
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from core.config import DB_PATH
@@ -69,6 +71,44 @@ CREATE TABLE IF NOT EXISTS captchas (
 );
 """
 
+# The baseline schema above is frozen. Every later change lives here as a
+# migration script; ``PRAGMA user_version`` records how many have been applied,
+# so the same code path upgrades existing databases and freshly created ones.
+_MIGRATIONS: list[str] = [
+    # v1: audit log, per-day message stats, soft-delete for warns.
+    """
+    ALTER TABLE warns ADD COLUMN deleted_at INTEGER;
+    CREATE INDEX idx_warns_active ON warns (chat_id, user_id) WHERE deleted_at IS NULL;
+
+    CREATE TABLE audit_log (
+        id         INTEGER PRIMARY KEY AUTOINCREMENT,
+        chat_id    INTEGER NOT NULL,
+        user_id    INTEGER,            -- target; NULL for chat-level events
+        actor_id   INTEGER,            -- moderator / web admin; NULL = bot automation
+        event      TEXT NOT NULL,
+        reason     TEXT,
+        meta       TEXT,               -- JSON blob with event-specific details
+        created_at INTEGER NOT NULL
+    );
+    CREATE INDEX idx_audit_chat_time  ON audit_log (chat_id, created_at);
+    CREATE INDEX idx_audit_event_time ON audit_log (event, created_at);
+    CREATE INDEX idx_audit_chat_user  ON audit_log (chat_id, user_id, created_at);
+
+    CREATE TABLE message_stats (
+        chat_id INTEGER NOT NULL,
+        day     TEXT    NOT NULL,     -- UTC 'YYYY-MM-DD'
+        user_id INTEGER NOT NULL,
+        count   INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (chat_id, day, user_id)
+    );
+    CREATE INDEX idx_msgstats_chat_day ON message_stats (chat_id, day);
+    """,
+]
+
+
+def _utc_day(ts: int) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d")
+
 
 def _now(now: Optional[int]) -> int:
     return int(time.time()) if now is None else now
@@ -94,6 +134,15 @@ class Storage:
                 # Better read/write concurrency for a long-running process.
                 self._conn.execute("PRAGMA journal_mode=WAL")
             self._conn.executescript(_SCHEMA)
+            self._conn.commit()
+            self._migrate()
+
+    def _migrate(self) -> None:
+        """Apply pending migrations; ``PRAGMA user_version`` gates what already ran."""
+        version = self._conn.execute("PRAGMA user_version").fetchone()[0]
+        for number, script in enumerate(_MIGRATIONS[version:], start=version + 1):
+            self._conn.executescript(script)
+            self._conn.execute(f"PRAGMA user_version = {number}")
             self._conn.commit()
 
     def close(self) -> None:
@@ -177,40 +226,45 @@ class Storage:
             return cur.lastrowid
 
     def count_warns(self, chat_id: int, user_id: int) -> int:
+        """Count a user's active (not soft-deleted) warns."""
         with self._lock:
             row = self._conn.execute(
-                "SELECT COUNT(*) AS n FROM warns WHERE chat_id = ? AND user_id = ?",
+                "SELECT COUNT(*) AS n FROM warns WHERE chat_id = ? AND user_id = ? AND deleted_at IS NULL",
                 (chat_id, user_id),
             ).fetchone()
         return row["n"]
 
-    def list_warns(self, chat_id: int, user_id: int) -> list[dict]:
+    def list_warns(self, chat_id: int, user_id: int, include_deleted: bool = False) -> list[dict]:
+        """Return a user's warns, oldest first; soft-deleted ones only on request."""
+        query = "SELECT id, chat_id, user_id, moderator_id, reason, created_at, deleted_at FROM warns WHERE chat_id = ? AND user_id = ?"
+        if not include_deleted:
+            query += " AND deleted_at IS NULL"
         with self._lock:
-            rows = self._conn.execute(
-                "SELECT id, chat_id, user_id, moderator_id, reason, created_at FROM warns WHERE chat_id = ? AND user_id = ? ORDER BY id",
-                (chat_id, user_id),
-            ).fetchall()
+            rows = self._conn.execute(f"{query} ORDER BY id", (chat_id, user_id)).fetchall()
         return [dict(r) for r in rows]
 
-    def remove_last_warn(self, chat_id: int, user_id: int) -> bool:
-        """Drop the most recent warn for a user; return True if one was removed."""
+    def remove_last_warn(self, chat_id: int, user_id: int, now: Optional[int] = None) -> bool:
+        """Soft-delete the most recent active warn; return True if one was removed.
+
+        Rows are kept for history/analytics and hard-deleted later by retention.
+        """
         with self._lock:
             row = self._conn.execute(
-                "SELECT id FROM warns WHERE chat_id = ? AND user_id = ? ORDER BY id DESC LIMIT 1",
+                "SELECT id FROM warns WHERE chat_id = ? AND user_id = ? AND deleted_at IS NULL ORDER BY id DESC LIMIT 1",
                 (chat_id, user_id),
             ).fetchone()
             if row is None:
                 return False
-            self._conn.execute("DELETE FROM warns WHERE id = ?", (row["id"],))
+            self._conn.execute("UPDATE warns SET deleted_at = ? WHERE id = ?", (_now(now), row["id"]))
             self._conn.commit()
         return True
 
-    def clear_warns(self, chat_id: int, user_id: int) -> int:
-        """Remove all warns for a user; return how many were removed."""
+    def clear_warns(self, chat_id: int, user_id: int, now: Optional[int] = None) -> int:
+        """Soft-delete all active warns for a user; return how many were affected."""
         with self._lock:
             cur = self._conn.execute(
-                "DELETE FROM warns WHERE chat_id = ? AND user_id = ?",
-                (chat_id, user_id),
+                "UPDATE warns SET deleted_at = ? WHERE chat_id = ? AND user_id = ? AND deleted_at IS NULL",
+                (_now(now), chat_id, user_id),
             )
             self._conn.commit()
             return cur.rowcount
@@ -284,6 +338,99 @@ class Storage:
                 (chat_id, name),
             ).fetchone()
         return row["value"] if row else 0
+
+    # -- audit log ---------------------------------------------------------------
+
+    def add_audit_event(
+        self,
+        chat_id: int,
+        event: str,
+        user_id: Optional[int] = None,
+        actor_id: Optional[int] = None,
+        reason: Optional[str] = None,
+        meta: Optional[dict] = None,
+        now: Optional[int] = None,
+    ) -> int:
+        """Append an event to the audit log; ``meta`` is stored as a JSON blob."""
+        payload = json.dumps(meta, ensure_ascii=False) if meta is not None else None
+        with self._lock:
+            cur = self._conn.execute(
+                "INSERT INTO audit_log (chat_id, user_id, actor_id, event, reason, meta, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (chat_id, user_id, actor_id, str(event), reason, payload, _now(now)),
+            )
+            self._conn.commit()
+            return cur.lastrowid
+
+    def list_audit_events(
+        self,
+        chat_id: Optional[int] = None,
+        event: Optional[str] = None,
+        user_id: Optional[int] = None,
+        since: Optional[int] = None,
+        until: Optional[int] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict]:
+        """Return audit events, newest first, filtered by any combination of args."""
+        clauses: list[str] = []
+        params: list = []
+        for clause, value in (
+            ("chat_id = ?", chat_id),
+            ("event = ?", event),
+            ("user_id = ?", user_id),
+            ("created_at >= ?", since),
+            ("created_at < ?", until),
+        ):
+            if value is not None:
+                clauses.append(clause)
+                params.append(value)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        with self._lock:
+            rows = self._conn.execute(
+                f"SELECT id, chat_id, user_id, actor_id, event, reason, meta, created_at FROM audit_log {where} ORDER BY id DESC LIMIT ? OFFSET ?",
+                (*params, limit, offset),
+            ).fetchall()
+        events = []
+        for row in rows:
+            item = dict(row)
+            item["meta"] = json.loads(item["meta"]) if item["meta"] is not None else None
+            events.append(item)
+        return events
+
+    # -- per-day message statistics ----------------------------------------------
+
+    def record_message_stat(self, chat_id: int, user_id: int, now: Optional[int] = None) -> None:
+        """Count a message towards the per-day statistics (UTC day buckets)."""
+        day = _utc_day(_now(now))
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO message_stats (chat_id, day, user_id, count) VALUES (?, ?, ?, 1) "
+                "ON CONFLICT(chat_id, day, user_id) DO UPDATE SET count = count + 1",
+                (chat_id, day, user_id),
+            )
+            self._conn.commit()
+
+    # -- retention -----------------------------------------------------------------
+
+    def purge_old_data(self, retention_days: int, now: Optional[int] = None) -> dict[str, int]:
+        """Hard-delete history older than ``retention_days`` (whole UTC days).
+
+        Only history is touched: audit events, soft-deleted warns and per-day
+        message stats. Live moderation state (active warns, mutes, members,
+        captchas, username cache, counters) is never purged. Returns the number
+        of rows removed per table.
+        """
+        cutoff_day = datetime.fromtimestamp(_now(now), tz=timezone.utc).date() - timedelta(days=retention_days)
+        cutoff_ts = int(datetime(cutoff_day.year, cutoff_day.month, cutoff_day.day, tzinfo=timezone.utc).timestamp())
+        cutoff_date = cutoff_day.strftime("%Y-%m-%d")
+        with self._lock:
+            counts = {
+                "audit_log": self._conn.execute("DELETE FROM audit_log WHERE created_at < ?", (cutoff_ts,)).rowcount,
+                "warns": self._conn.execute("DELETE FROM warns WHERE deleted_at IS NOT NULL AND deleted_at < ?", (cutoff_ts,)).rowcount,
+                "message_stats": self._conn.execute("DELETE FROM message_stats WHERE day < ?", (cutoff_date,)).rowcount,
+            }
+            self._conn.commit()
+        return counts
 
     # -- username -> id cache --------------------------------------------------
 

--- a/src/handlers/admin_handlers.py
+++ b/src/handlers/admin_handlers.py
@@ -6,6 +6,7 @@ from telegram import ChatPermissions, Update
 from telegram.error import BadRequest, Forbidden
 from telegram.ext import ContextTypes
 
+from core.audit import AuditEvent, record_event
 from core.config import DELETE_ON_BAN, logger
 from core.duration import format_duration, parse_duration
 from core.storage import get_storage
@@ -174,6 +175,7 @@ async def ban_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     if not await _apply_action(update, lambda: chat.ban_member(user_id=target.id, until_date=until_ts), f"🔨 Пользователь забанен{suffix}."):
         return
+    await record_event(chat.id, AuditEvent.BAN, user_id=target.id, actor_id=update.effective_user.id, meta={"until": until_ts})
     logger.info(f"[INFO] User with ID {target.id} was banned (until={until_ts})")
 
     # Remove the offending message the ban was issued in reply to.
@@ -195,6 +197,7 @@ async def unban_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
     chat = update.effective_chat
     if not await _apply_action(update, lambda: chat.unban_member(user_id=target.id), "✅ Пользователь разбанен."):
         return
+    await record_event(chat.id, AuditEvent.UNBAN, user_id=target.id, actor_id=update.effective_user.id)
     logger.info(f"[INFO] User with ID {target.id} was unbanned")
 
 
@@ -216,6 +219,7 @@ async def kick_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     if not await _apply_action(update, _kick, "👢 Пользователь кикнут."):
         return
+    await record_event(chat.id, AuditEvent.KICK, user_id=target.id, actor_id=update.effective_user.id)
     logger.info(f"[INFO] User with ID {target.id} was kicked")
 
 
@@ -238,6 +242,7 @@ async def mute_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     # Native until_date lifts the mute automatically; we also record it so the
     # state is visible and survives a restart.
     await asyncio.to_thread(get_storage().add_mute, chat.id, target.id, until_ts)
+    await record_event(chat.id, AuditEvent.MUTE, user_id=target.id, actor_id=update.effective_user.id, meta={"until": until_ts})
     logger.info(f"[INFO] User with ID {target.id} was muted (until={until_ts})")
 
 
@@ -252,4 +257,5 @@ async def unmute_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     if not await _apply_action(update, lambda: chat.restrict_member(user_id=target.id, permissions=UNMUTE_PERMISSIONS), "🔊 Пользователь размьючен."):
         return
     await asyncio.to_thread(get_storage().remove_mute, chat.id, target.id)
+    await record_event(chat.id, AuditEvent.UNMUTE, user_id=target.id, actor_id=update.effective_user.id)
     logger.info(f"[INFO] User with ID {target.id} was unmuted")

--- a/src/handlers/captcha.py
+++ b/src/handlers/captcha.py
@@ -21,6 +21,7 @@ from telegram.error import BadRequest, Forbidden, TelegramError
 from telegram.ext import ContextTypes
 
 from core import config
+from core.audit import AuditEvent, record_event
 from core.config import CHAT_RULES_URL, logger
 from core.storage import get_storage
 
@@ -66,6 +67,7 @@ async def start_challenge(chat, user: User) -> None:
     _pending[_key(chat.id, user.id)] = message.message_id
     await asyncio.to_thread(get_storage().add_captcha, chat.id, user.id, message.message_id, deadline)
     _track(asyncio.create_task(_expire(chat, user.id)))
+    await record_event(chat.id, AuditEvent.CAPTCHA_SHOWN, user_id=user.id, meta={"timeout": config.CAPTCHA_TIMEOUT})
     logger.info("[INFO] Captcha started for user %s", user.id)
 
 
@@ -92,6 +94,7 @@ async def _punish_if_pending(chat, user_id: int) -> None:
         if config.CAPTCHA_FAIL_ACTION == "kick":
             # Kick = ban + unban, so the user may rejoin and try again.
             await chat.unban_member(user_id=user_id)
+        await record_event(chat.id, AuditEvent.CAPTCHA_FAILED, user_id=user_id, meta={"action": config.CAPTCHA_FAIL_ACTION})
     except (BadRequest, Forbidden) as exc:
         logger.warning("[WARN] Captcha fail-action for %s failed: %s", user_id, exc)
     logger.info("[INFO] Captcha timed out for user %s (action=%s)", user_id, config.CAPTCHA_FAIL_ACTION)
@@ -145,6 +148,7 @@ async def captcha_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     except (BadRequest, Forbidden) as exc:
         logger.warning("[WARN] Could not unmute %s after captcha: %s", target_id, exc)
     await asyncio.to_thread(get_storage().remove_mute, chat.id, target_id)
+    await record_event(chat.id, AuditEvent.CAPTCHA_PASSED, user_id=target_id)
 
     await query.answer("Спасибо! Доступ открыт.")
     if message_id is not None:

--- a/src/handlers/flood_control.py
+++ b/src/handlers/flood_control.py
@@ -15,6 +15,7 @@ from telegram.error import BadRequest, Forbidden
 from telegram.ext import ContextTypes
 
 from core import config
+from core.audit import AuditEvent, record_event
 from core.config import logger
 from core.storage import get_storage
 
@@ -77,6 +78,7 @@ async def flood_control(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     storage = get_storage()
     await asyncio.to_thread(storage.add_mute, chat.id, user.id, until_ts)
     await asyncio.to_thread(storage.increment_counter, chat.id, "flood_muted")
+    await record_event(chat.id, AuditEvent.FLOOD_MUTE, user_id=user.id, meta={"seconds": config.FLOOD_MUTE_SECONDS})
     _tracker.reset(key)
 
     logger.info("[INFO] User %s muted for %ss for flooding", user.id, config.FLOOD_MUTE_SECONDS)

--- a/src/handlers/media_moderation.py
+++ b/src/handlers/media_moderation.py
@@ -14,6 +14,7 @@ from telegram.error import BadRequest, Forbidden
 from telegram.ext import ContextTypes, filters
 
 from core import config
+from core.audit import AuditEvent, record_event
 from core.config import logger
 
 # Background tasks for self-deleting notices; kept referenced so they are not
@@ -81,6 +82,7 @@ async def moderate_media(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     except (BadRequest, Forbidden) as exc:
         logger.debug("[DEBUG] Could not delete media message: %s", exc)
         return
+    await record_event(chat.id, AuditEvent.MEDIA_DELETED, user_id=user.id, meta={"type": label})
     logger.info("[INFO] Deleted %s from user %s", label, user.id)
 
     if not config.MEDIA_NOTIFY:

--- a/src/handlers/message_moderation.py
+++ b/src/handlers/message_moderation.py
@@ -14,6 +14,7 @@ from telegram.error import BadRequest, Forbidden
 from telegram.ext import ContextTypes
 
 from core import config
+from core.audit import AuditEvent, record_event
 from core.config import logger
 from core.storage import get_storage
 
@@ -60,6 +61,7 @@ async def _enforce(update: Update, context: ContextTypes.DEFAULT_TYPE, user_id: 
         logger.debug("[DEBUG] Could not delete newcomer message: %s", exc)
 
     await asyncio.to_thread(storage.increment_counter, chat.id, "newcomer_filtered")
+    await record_event(chat.id, AuditEvent.NEWCOMER_FILTERED, user_id=user_id, reason=reason, meta={"action": config.NEWCOMER_ACTION})
 
     if config.NEWCOMER_ACTION == "mute":
         try:
@@ -70,9 +72,11 @@ async def _enforce(update: Update, context: ContextTypes.DEFAULT_TYPE, user_id: 
     elif config.NEWCOMER_ACTION == "warn":
         await asyncio.to_thread(storage.add_warn, chat.id, user_id, context.bot.id, f"авто: {reason}")
         count = await asyncio.to_thread(storage.count_warns, chat.id, user_id)
+        await record_event(chat.id, AuditEvent.WARN, user_id=user_id, actor_id=context.bot.id, reason=f"авто: {reason}", meta={"count": count})
         if count >= config.WARN_LIMIT:
             await _auto_punish(update, user_id)
             await asyncio.to_thread(storage.clear_warns, chat.id, user_id)
+            await record_event(chat.id, AuditEvent.WARNS_CLEARED, user_id=user_id, meta={"trigger": "auto_punish", "count": count})
 
     logger.info("[INFO] Newcomer %s message filtered (%s, action=%s)", user_id, reason, config.NEWCOMER_ACTION)
 

--- a/src/handlers/user_cache.py
+++ b/src/handlers/user_cache.py
@@ -1,21 +1,36 @@
-"""Cache @username -> id for every user we see.
+"""Cache @username -> id for every user we see, and count message statistics.
 
 The Bot API cannot resolve a @username to an id on demand, so the bot
 remembers the mapping for everyone who writes in the chat. This is what makes
 ``/ban @user`` possible without a message to reply to.
+
+This group-2 handler sees every non-service message, so it is also where
+per-day message statistics are counted (all message types, unlike
+``members.message_count`` which only counts what the newcomer filter sees).
 """
 
 import asyncio
 
 from telegram import Update
+from telegram.constants import ChatType
 from telegram.ext import ContextTypes
 
 from core.storage import get_storage
 
 
 async def cache_seen_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Record the author's @username -> id mapping (no-op without a username)."""
+    """Record the author's @username -> id mapping and count the message."""
     user = update.effective_user
-    if user is None or user.is_bot or not user.username:
+    chat = update.effective_chat
+    if user is None or chat is None or user.is_bot:
         return
-    await asyncio.to_thread(get_storage().remember_user, user.id, user.username)
+
+    storage = get_storage()
+    # Count fresh group messages only: edits are not new messages, and private
+    # DMs are not part of any chat's statistics.
+    if update.edited_message is None and chat.type != ChatType.PRIVATE:
+        await asyncio.to_thread(storage.record_message_stat, chat.id, user.id)
+
+    if not user.username:
+        return
+    await asyncio.to_thread(storage.remember_user, user.id, user.username)

--- a/src/handlers/user_handlers.py
+++ b/src/handlers/user_handlers.py
@@ -6,6 +6,7 @@ from telegram.constants import ParseMode
 from telegram.ext import ContextTypes
 
 from core import config
+from core.audit import AuditEvent, record_event
 from core.cas import casapi
 from core.config import CHAT_RULES_URL
 from core.storage import get_storage
@@ -33,6 +34,7 @@ async def greet_chat_members(update: Update, context: ContextTypes.DEFAULT_TYPE)
         # cache the joiner's @username so they can be targeted by name later.
         await asyncio.to_thread(storage.record_member, update.effective_chat.id, user_id)
         await asyncio.to_thread(storage.remember_user, user_id, new_user.username)
+        await record_event(update.effective_chat.id, AuditEvent.MEMBER_JOINED, user_id=user_id)
         check = await asyncio.to_thread(casapi.check, user_id=user_id)
         logger.debug(f"[DEBUG] User with ID {user_id} was checked")
         # CAS returns ok=True when the user is listed as a spammer,
@@ -41,6 +43,7 @@ async def greet_chat_members(update: Update, context: ContextTypes.DEFAULT_TYPE)
             # CAS hit -> ban outright, skipping the captcha.
             logger.info(f"[INFO] User with ID {user_id} found in CAS, was banned")
             await update.effective_chat.ban_member(user_id=user_id)
+            await record_event(update.effective_chat.id, AuditEvent.CAS_BAN, user_id=user_id)
         elif config.CAPTCHA_ENABLED:
             # Make the newcomer pass the captcha before they can write or be greeted.
             await start_challenge(update.effective_chat, new_user)
@@ -51,4 +54,6 @@ async def greet_chat_members(update: Update, context: ContextTypes.DEFAULT_TYPE)
                 link_preview_options=LinkPreviewOptions(is_disabled=True),
             )
     elif was_member and not is_member:
-        logger.debug(f"[INFO] User with ID {update.chat_member.new_chat_member.user.id} was leave")
+        left_user_id = update.chat_member.new_chat_member.user.id
+        await record_event(update.effective_chat.id, AuditEvent.MEMBER_LEFT, user_id=left_user_id)
+        logger.debug(f"[INFO] User with ID {left_user_id} was leave")

--- a/src/handlers/warn_handlers.py
+++ b/src/handlers/warn_handlers.py
@@ -6,6 +6,7 @@ from telegram.error import BadRequest, Forbidden
 from telegram.ext import ContextTypes
 from telegram.helpers import escape
 
+from core.audit import AuditEvent, record_event
 from core.config import WARN_ACTION, WARN_LIMIT, logger
 from core.storage import get_storage
 
@@ -33,11 +34,13 @@ async def _auto_punish(update: Update, user_id: int) -> str:
     try:
         if WARN_ACTION == "ban":
             await chat.ban_member(user_id=user_id)
+            await record_event(chat.id, AuditEvent.AUTO_BAN, user_id=user_id, meta={"trigger": "warn_limit"})
             logger.info(f"[INFO] User {user_id} auto-banned after reaching warn limit")
             return "забанен"
         await chat.restrict_member(user_id=user_id, permissions=MUTE_PERMISSIONS)
         # Persist the mute so its state survives a restart.
         await asyncio.to_thread(get_storage().add_mute, chat.id, user_id, None)
+        await record_event(chat.id, AuditEvent.AUTO_MUTE, user_id=user_id, meta={"trigger": "warn_limit"})
         logger.info(f"[INFO] User {user_id} auto-muted after reaching warn limit")
         return "замьючен"
     except (BadRequest, Forbidden) as exc:
@@ -59,13 +62,15 @@ async def warn_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     storage = get_storage()
     await asyncio.to_thread(storage.add_warn, chat.id, target.id, moderator.id, reason)
     count = await asyncio.to_thread(storage.count_warns, chat.id, target.id)
+    await record_event(chat.id, AuditEvent.WARN, user_id=target.id, actor_id=moderator.id, reason=reason, meta={"count": count})
 
     text = f"⚠️ {target.mention_html()} предупреждён ({count}/{WARN_LIMIT}).\nПричина: {escape(reason) if reason else '—'}"
 
     if count >= WARN_LIMIT:
         outcome = await _auto_punish(update, target.id)
-        # Reset the counter so the next cycle starts clean.
+        # Reset the counter so the next cycle starts clean (soft-delete keeps history).
         await asyncio.to_thread(storage.clear_warns, chat.id, target.id)
+        await record_event(chat.id, AuditEvent.WARNS_CLEARED, user_id=target.id, meta={"trigger": "auto_punish", "count": count})
         text += f"\n\nДостигнут лимит предупреждений — пользователь {outcome}. Счётчик сброшен."
 
     await update.effective_message.reply_html(text)
@@ -109,5 +114,6 @@ async def unwarn_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         return
 
     count = await asyncio.to_thread(storage.count_warns, chat.id, target.id)
+    await record_event(chat.id, AuditEvent.UNWARN, user_id=target.id, actor_id=update.effective_user.id, meta={"count": count})
     await update.effective_message.reply_html(f"С {target.mention_html()} снято последнее предупреждение. Осталось: {count}/{WARN_LIMIT}.")
     await _delete_command(update)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,29 @@
 import os
 import sys
 
+import pytest
+
 # Make the bot's source root importable (bot.py imports `core.*`, `handlers.*`)
 SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
 if SRC not in sys.path:
     sys.path.insert(0, SRC)
+
+
+@pytest.fixture(autouse=True)
+def audit_store(monkeypatch):
+    """Give every test an in-memory storage for audit events.
+
+    Handlers record audit events through ``core.audit.get_storage`` (not the
+    per-module ``get_storage`` the tests monkeypatch), so without this fixture
+    instrumented handlers would create a real ``moder.db`` during tests. The
+    process-wide singleton is patched too, so any unpatched ``get_storage()``
+    call stays in memory. Request the fixture by name to assert on audit rows.
+    """
+    from core import audit, storage
+    from core.storage import Storage
+
+    s = Storage(":memory:")
+    monkeypatch.setattr(audit, "get_storage", lambda: s)
+    monkeypatch.setattr(storage, "_storage", s)
+    yield s
+    s.close()

--- a/tests/test_admin_targets.py
+++ b/tests/test_admin_targets.py
@@ -31,6 +31,7 @@ class FakeMessage:
 
 class FakeChat:
     def __init__(self, admins):
+        self.id = 100
         self._admins = admins
         self.banned = []
         self.restricted = []

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,79 @@
+import asyncio
+
+import pytest
+
+from core import audit
+from core.audit import AuditEvent, record_event
+from core.storage import Storage
+
+
+@pytest.fixture
+def store():
+    s = Storage(":memory:")
+    yield s
+    s.close()
+
+
+# -- storage layer -----------------------------------------------------------
+
+
+def test_add_and_list_events_newest_first(store):
+    store.add_audit_event(1, "warn", user_id=42, actor_id=7, reason="спам", now=100)
+    store.add_audit_event(1, "ban", user_id=42, actor_id=7, now=200)
+    events = store.list_audit_events(chat_id=1)
+    assert [e["event"] for e in events] == ["ban", "warn"]
+    assert events[1]["reason"] == "спам"
+
+
+def test_meta_json_round_trip(store):
+    store.add_audit_event(1, "mute", user_id=42, meta={"until": 500, "источник": "тест"}, now=100)
+    event = store.list_audit_events(chat_id=1)[0]
+    assert event["meta"] == {"until": 500, "источник": "тест"}
+    store.add_audit_event(1, "kick", user_id=42, now=200)
+    assert store.list_audit_events(event="kick")[0]["meta"] is None
+
+
+def test_list_events_filters(store):
+    store.add_audit_event(1, "warn", user_id=42, now=100)
+    store.add_audit_event(1, "warn", user_id=43, now=200)
+    store.add_audit_event(2, "ban", user_id=42, now=300)
+
+    assert len(store.list_audit_events(chat_id=1)) == 2
+    assert len(store.list_audit_events(event="ban")) == 1
+    assert len(store.list_audit_events(user_id=42)) == 2
+    assert len(store.list_audit_events(since=200)) == 2  # inclusive lower bound
+    assert len(store.list_audit_events(until=200)) == 1  # exclusive upper bound
+    assert len(store.list_audit_events(chat_id=1, user_id=43, event="warn")) == 1
+
+
+def test_list_events_pagination(store):
+    for i in range(5):
+        store.add_audit_event(1, "warn", user_id=42, now=100 + i)
+    page = store.list_audit_events(chat_id=1, limit=2, offset=2)
+    assert [e["created_at"] for e in page] == [102, 101]
+
+
+def test_event_accepts_strenum(store):
+    store.add_audit_event(1, AuditEvent.CAS_BAN, user_id=42, now=100)
+    assert store.list_audit_events(event="cas_ban")[0]["event"] == "cas_ban"
+
+
+# -- record_event helper -------------------------------------------------------
+
+
+def test_record_event_persists(audit_store):
+    asyncio.run(record_event(1, AuditEvent.WARN, user_id=42, actor_id=7, reason="спам", meta={"count": 1}))
+    events = audit_store.list_audit_events(chat_id=1)
+    assert len(events) == 1
+    assert events[0]["event"] == "warn"
+    assert events[0]["actor_id"] == 7
+    assert events[0]["meta"] == {"count": 1}
+
+
+def test_record_event_swallows_storage_errors(monkeypatch):
+    def _boom():
+        raise RuntimeError("db is gone")
+
+    monkeypatch.setattr(audit, "get_storage", _boom)
+    # Must not raise — a broken audit trail must never break moderation.
+    asyncio.run(record_event(1, AuditEvent.BAN, user_id=42))

--- a/tests/test_ban_delete.py
+++ b/tests/test_ban_delete.py
@@ -31,6 +31,7 @@ class FakeMessage:
 
 class FakeChat:
     def __init__(self, admins):
+        self.id = 100
         self._admins = admins
         self.banned = []
 

--- a/tests/test_command_feedback.py
+++ b/tests/test_command_feedback.py
@@ -33,6 +33,7 @@ class FakeMessage:
 
 class FakeChat:
     def __init__(self, admins, fail=False):
+        self.id = 100
         self._admins = admins
         self._fail = fail
         self.banned = []

--- a/tests/test_media_moderation.py
+++ b/tests/test_media_moderation.py
@@ -33,6 +33,7 @@ class FakeMessage:
 
 class FakeChat:
     def __init__(self, admins=()):
+        self.id = 100
         self._admins = list(admins)
         self.sent = []
 

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,0 +1,86 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from core.retention import seconds_until
+from core.storage import Storage
+
+
+@pytest.fixture
+def store():
+    s = Storage(":memory:")
+    yield s
+    s.close()
+
+
+def _ts(*args) -> int:
+    return int(datetime(*args, tzinfo=timezone.utc).timestamp())
+
+
+# -- next-run computation ------------------------------------------------------
+
+
+def test_seconds_until_later_today():
+    assert seconds_until(4, now=_ts(2026, 7, 1, 2, 0)) == 2 * 3600
+
+
+def test_seconds_until_wraps_to_next_day():
+    assert seconds_until(4, now=_ts(2026, 7, 1, 5, 0)) == 23 * 3600
+
+
+def test_seconds_until_exact_hour_waits_full_day():
+    assert seconds_until(4, now=_ts(2026, 7, 1, 4, 0)) == 24 * 3600
+
+
+# -- purge policy ----------------------------------------------------------------
+
+NOW = _ts(2026, 7, 1, 12, 0)
+CUTOFF = _ts(2026, 6, 21)  # retention_days=10 -> start of UTC day 10 days back
+
+
+def test_purge_audit_log_boundary(store):
+    store.add_audit_event(1, "warn", user_id=42, now=CUTOFF - 1)
+    store.add_audit_event(1, "warn", user_id=42, now=CUTOFF)
+    counts = store.purge_old_data(10, now=NOW)
+    assert counts["audit_log"] == 1
+    assert [e["created_at"] for e in store.list_audit_events(chat_id=1)] == [CUTOFF]
+
+
+def test_purge_removes_only_soft_deleted_warns(store):
+    # Old but still active warn: live moderation state, must survive.
+    store.add_warn(1, 42, reason="активный", now=CUTOFF - 100)
+    # Soft-deleted long ago: history past retention, must go.
+    store.add_warn(1, 43, reason="старый", now=CUTOFF - 100)
+    store.remove_last_warn(1, 43, now=CUTOFF - 50)
+    # Soft-deleted recently: history still within retention, must survive.
+    store.add_warn(1, 44, reason="свежий", now=CUTOFF - 100)
+    store.remove_last_warn(1, 44, now=CUTOFF + 50)
+
+    counts = store.purge_old_data(10, now=NOW)
+    assert counts["warns"] == 1
+    assert store.count_warns(1, 42) == 1
+    assert store.list_warns(1, 43, include_deleted=True) == []
+    assert len(store.list_warns(1, 44, include_deleted=True)) == 1
+
+
+def test_purge_message_stats_by_day(store):
+    store.record_message_stat(1, 42, now=CUTOFF - 1)  # 2026-06-20
+    store.record_message_stat(1, 42, now=CUTOFF)  # 2026-06-21
+    counts = store.purge_old_data(10, now=NOW)
+    assert counts["message_stats"] == 1
+
+
+def test_purge_leaves_state_tables_alone(store):
+    store.record_member(1, 42, now=100)
+    store.add_mute(1, 42, until=None, now=100)
+    store.add_captcha(1, 42, message_id=5, deadline=200)
+    store.remember_user(42, "alice")
+    store.increment_counter(1, "flood_muted")
+
+    store.purge_old_data(10, now=NOW)
+
+    assert store.get_member(1, 42) is not None
+    assert store.is_muted(1, 42, now=NOW) is True
+    assert len(store.list_captchas()) == 1
+    assert store.resolve_username("alice") == 42
+    assert store.get_counter(1, "flood_muted") == 1

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,6 +1,8 @@
+import sqlite3
+
 import pytest
 
-from core.storage import Storage
+from core.storage import _SCHEMA, Storage
 
 
 @pytest.fixture
@@ -70,6 +72,97 @@ def test_clear_warns(store):
     store.add_warn(1, 42, now=200)
     assert store.clear_warns(1, 42) == 2
     assert store.count_warns(1, 42) == 0
+
+
+# -- warns: soft-delete ------------------------------------------------------
+
+
+def test_clear_warns_keeps_history(store):
+    store.add_warn(1, 42, reason="a", now=100)
+    store.add_warn(1, 42, reason="b", now=200)
+    store.clear_warns(1, 42, now=300)
+    assert store.list_warns(1, 42) == []
+    history = store.list_warns(1, 42, include_deleted=True)
+    assert [w["reason"] for w in history] == ["a", "b"]
+    assert all(w["deleted_at"] == 300 for w in history)
+
+
+def test_remove_last_warn_keeps_history(store):
+    store.add_warn(1, 42, reason="a", now=100)
+    store.add_warn(1, 42, reason="b", now=200)
+    assert store.remove_last_warn(1, 42, now=300) is True
+    assert [w["reason"] for w in store.list_warns(1, 42)] == ["a"]
+    assert len(store.list_warns(1, 42, include_deleted=True)) == 2
+
+
+def test_remove_last_warn_skips_soft_deleted(store):
+    store.add_warn(1, 42, reason="a", now=100)
+    store.remove_last_warn(1, 42, now=200)
+    # The only warn left is already soft-deleted — nothing to remove.
+    assert store.remove_last_warn(1, 42, now=300) is False
+
+
+def test_warn_cycle_restarts_after_clear(store):
+    store.add_warn(1, 42, now=100)
+    store.add_warn(1, 42, now=200)
+    store.clear_warns(1, 42, now=300)
+    store.add_warn(1, 42, now=400)
+    assert store.count_warns(1, 42) == 1  # the next cycle starts clean
+
+
+# -- message stats -----------------------------------------------------------
+
+
+def test_record_message_stat_buckets_by_utc_day(store):
+    day1, day2 = 1_700_000_000, 1_700_000_000 + 86400  # consecutive UTC days
+    store.record_message_stat(1, 42, now=day1)
+    store.record_message_stat(1, 42, now=day1 + 60)
+    store.record_message_stat(1, 42, now=day2)
+    store.record_message_stat(1, 43, now=day2)
+    rows = store._conn.execute("SELECT day, user_id, count FROM message_stats ORDER BY day, user_id").fetchall()
+    assert [(r["day"], r["user_id"], r["count"]) for r in rows] == [
+        ("2023-11-14", 42, 2),
+        ("2023-11-15", 42, 1),
+        ("2023-11-15", 43, 1),
+    ]
+
+
+# -- migrations ----------------------------------------------------------------
+
+
+def test_migration_upgrades_v0_database(tmp_path):
+    # Build a database exactly as the pre-migration bot would have left it.
+    db = str(tmp_path / "old.db")
+    conn = sqlite3.connect(db)
+    conn.executescript(_SCHEMA)
+    conn.execute("INSERT INTO warns (chat_id, user_id, moderator_id, reason, created_at) VALUES (1, 42, 7, 'spam', 100)")
+    conn.commit()
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 0
+    conn.close()
+
+    s = Storage(db)
+    assert s._conn.execute("PRAGMA user_version").fetchone()[0] == 1
+    columns = {row[1] for row in s._conn.execute("PRAGMA table_info(warns)")}
+    assert "deleted_at" in columns
+    # Pre-existing warns survive the migration and count as active.
+    assert s.count_warns(1, 42) == 1
+    s.add_audit_event(1, "ban", user_id=42, now=200)  # new tables are usable
+    s.record_message_stat(1, 42, now=200)
+    s.close()
+
+
+def test_fresh_database_is_fully_migrated(store):
+    assert store._conn.execute("PRAGMA user_version").fetchone()[0] == 1
+
+
+def test_migration_is_idempotent_across_reconnect(tmp_path):
+    db = str(tmp_path / "m.db")
+    a = Storage(db)
+    a.add_audit_event(1, "warn", user_id=42, now=100)
+    a.close()
+    b = Storage(db)  # reopening must not re-run migrations
+    assert len(b.list_audit_events(chat_id=1)) == 1
+    b.close()
 
 
 # -- mutes -----------------------------------------------------------------

--- a/tests/test_user_cache.py
+++ b/tests/test_user_cache.py
@@ -13,9 +13,21 @@ class FakeUser:
         self.is_bot = is_bot
 
 
+class FakeChat:
+    def __init__(self, chat_id=100, chat_type="supergroup"):
+        self.id = chat_id
+        self.type = chat_type
+
+
 class FakeUpdate:
-    def __init__(self, user):
+    def __init__(self, user, chat=None, edited=False):
         self.effective_user = user
+        self.effective_chat = chat if chat is not None else FakeChat()
+        self.edited_message = object() if edited else None
+
+
+def _stat_rows(store):
+    return store._conn.execute("SELECT chat_id, user_id, count FROM message_stats").fetchall()
 
 
 @pytest.fixture
@@ -39,3 +51,28 @@ def test_ignores_user_without_username(store):
 def test_ignores_bots(store):
     asyncio.run(uc.cache_seen_user(FakeUpdate(FakeUser(42, "botname", is_bot=True)), None))
     assert store.resolve_username("botname") is None
+    assert _stat_rows(store) == []
+
+
+def test_counts_message_stats(store):
+    asyncio.run(uc.cache_seen_user(FakeUpdate(FakeUser(42, "alice")), None))
+    asyncio.run(uc.cache_seen_user(FakeUpdate(FakeUser(42, "alice")), None))
+    rows = _stat_rows(store)
+    assert [(r["chat_id"], r["user_id"], r["count"]) for r in rows] == [(100, 42, 2)]
+
+
+def test_counts_stats_even_without_username(store):
+    asyncio.run(uc.cache_seen_user(FakeUpdate(FakeUser(42, None)), None))
+    assert len(_stat_rows(store)) == 1
+
+
+def test_edits_are_not_counted(store):
+    asyncio.run(uc.cache_seen_user(FakeUpdate(FakeUser(42, "alice"), edited=True), None))
+    assert _stat_rows(store) == []
+    assert store.resolve_username("alice") == 42  # username still cached
+
+
+def test_private_chats_are_not_counted(store):
+    asyncio.run(uc.cache_seen_user(FakeUpdate(FakeUser(42, "alice"), chat=FakeChat(chat_type="private")), None))
+    assert _stat_rows(store) == []
+    assert store.resolve_username("alice") == 42

--- a/tests/test_warn_handlers.py
+++ b/tests/test_warn_handlers.py
@@ -182,3 +182,42 @@ def test_unwarn_when_none(store):
     update, command, chat, ctx = _make(target)
     asyncio.run(warns.unwarn_user(update, ctx))
     assert "нет предупреждений" in command.replies[0]
+
+
+# -- audit trail -------------------------------------------------------------
+
+
+def test_warn_records_audit_event(store, audit_store, monkeypatch):
+    monkeypatch.setattr(warns, "WARN_LIMIT", 3)
+    target = FakeUser(42)
+    update, command, chat, ctx = _make(target, args=["спам"])
+    asyncio.run(warns.warn_user(update, ctx))
+    events = audit_store.list_audit_events(chat_id=100)
+    assert [e["event"] for e in events] == ["warn"]
+    assert events[0]["user_id"] == 42
+    assert events[0]["actor_id"] == 5
+    assert events[0]["reason"] == "спам"
+
+
+def test_auto_punish_records_full_audit_trail(store, audit_store, monkeypatch):
+    monkeypatch.setattr(warns, "WARN_LIMIT", 1)
+    monkeypatch.setattr(warns, "WARN_ACTION", "mute")
+    target = FakeUser(42)
+    update, command, chat, ctx = _make(target)
+    asyncio.run(warns.warn_user(update, ctx))
+    # Newest first: the warn itself, then the punishment, then the reset.
+    events = [e["event"] for e in audit_store.list_audit_events(chat_id=100)]
+    assert events == ["warns_cleared", "auto_mute", "warn"]
+    # History survives the reset even though the live counter is back to zero.
+    assert store.count_warns(100, 42) == 0
+    assert len(store.list_warns(100, 42, include_deleted=True)) == 1
+
+
+def test_unwarn_records_audit_event(store, audit_store):
+    store.add_warn(100, 42, now=1700000000)
+    target = FakeUser(42)
+    update, command, chat, ctx = _make(target)
+    asyncio.run(warns.unwarn_user(update, ctx))
+    events = audit_store.list_audit_events(chat_id=100, event="unwarn")
+    assert len(events) == 1
+    assert events[0]["user_id"] == 42


### PR DESCRIPTION
## Что это

Этап 1 из плана «веб-панель администрирования»: слой данных, на который дальше встанет дашборд (этап 2) и управление из веба (этап 3).

## Изменения

**Audit-log** (`src/core/audit.py`, миграция в `storage.py`): каждое действие модерации теперь пишется в таблицу `audit_log` с целью, актором, причиной и meta-JSON — ban/unban/kick/mute/unmute, warn/unwarn/warns_cleared, auto_ban/auto_mute, captcha shown/passed/failed, cas_ban, flood_mute, newcomer_filtered, media_deleted, member_joined/left. Событие записывается только после успешного действия в Telegram; сбой записи аудита никогда не ломает модерацию.

**Статистика сообщений**: подневный агрегат `message_stats(chat_id, day, user_id, count)` (UTC-бакеты) вместо события на каждое сообщение — даёт графики по дням и «топ писателей» при ограниченном росте БД. Считается в group-2 хендлере `cache_seen_user` (все типы сообщений, без редактирований и личек).

**Мягкое удаление варнов**: `clear_warns`/`remove_last_warn` теперь ставят `deleted_at` вместо DELETE — история переживает автонаказание. `count_warns` считает только активные, семантика сброса лимита не изменилась.

**Миграции схемы**: `PRAGMA user_version` + список `_MIGRATIONS`; v0-схема заморожена как baseline. Существующая БД обновляется на старте без ручных шагов.

**Ретеншен**: ежедневная джоба (plain asyncio-таск, как капча-таймеры) удаляет историю старше `storage.retention.days` (дефолт 365, env `RETENTION_DAYS`) в `purge_hour_utc` (дефолт 04:00 UTC). Чистятся только audit_log, soft-deleted варны и message_stats; живое состояние (активные варны, мьюты, members, капчи) не трогается. Прогон также выполняется сразу на старте — догоняет пропущенное после даунтайма.

## Тесты

156 passed: миграция v0→v1 на «старой» БД, soft-delete циклы, границы purge по каждой таблице, фильтры audit-запросов, бакетирование статистики, autouse-фикстура в conftest, чтобы инструментированные хендлеры не создавали реальный `moder.db` в тестах.

## Следующие этапы

- Этап 2: FastAPI + Jinja2 + htmx дашборд (read-only), Telegram Login Widget, `/healthz`
- Этап 3: управление из веба (ban/mute, принудительный компактинг с подтверждением + VACUUM)